### PR TITLE
Test CI for a "crazy" hack to make Module#include "compatible" for Ruby 2.7 and Ruby 3.0 

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,3 +18,5 @@
 | Medium | ⏳ | Custom matcher to track `ConvenientService::Logger` messages | |
 | Medium | 🚧 | Remove `respond_to?` from `Copyable` | Investigate before making any decision |
 | High | 🚧 | Unified `inspect` | |
+| High | 🚧 | Remove race condition for `method_missing` | |
+| High | 🚧 | Remove incompatiility of [Module#include](https://gist.github.com/marian13/9c25041f835564e945d978839097d419) | |

--- a/lib/convenient_service/configs/aliases.rb
+++ b/lib/convenient_service/configs/aliases.rb
@@ -3,7 +3,5 @@
 module ConvenientService
   module Standard
     Config = ::ConvenientService::Configs::Standard
-    CommittedConfig = ::ConvenientService::Configs::StandardCommitted
-    UncommittedConfig = ::ConvenientService::Configs::StandardUncommitted
   end
 end

--- a/lib/convenient_service/configs/standard.rb
+++ b/lib/convenient_service/configs/standard.rb
@@ -2,7 +2,7 @@
 
 module ConvenientService
   module Configs
-    module StandardUncommitted
+    module Standard
       include Support::Concern
 
       ##
@@ -189,72 +189,5 @@ module ConvenientService
       end
       # rubocop:enable Lint/ConstantDefinitionInBlock
     end
-  end
-end
-
-module ConvenientService
-  module Configs
-    ##
-    # NOTE: A copy of `StandardUncommitted` config, that automatically commits itself after the `include` invocation.
-    #
-    # For example:
-    #
-    #   class PerformOperation
-    #     include ConvenientService::Configs::StandardCommitted
-    #     # ...
-    #   end
-    #
-    # is roughly equivalent to:
-    #
-    #   class PerformOperation
-    #     include ConvenientService::Configs::StandardUncommitted
-    #
-    #     commit_config!
-    #     # ...
-    #   end
-    #
-    StandardCommitted = StandardUncommitted.dup.tap do |mod|
-      mod.module_exec do
-        def self.included(klass)
-          klass.commit_config!
-        end
-      end
-    end
-  end
-end
-
-module ConvenientService
-  module Configs
-    ##
-    # IMPORTANT: Breaking change!!!
-    # Automatic config commitment by `method_missing` does NOT work in Ruby 2.7.
-    # That is probably caused by `(*args, **kwargs, &block)` delegation.
-    # Check the following article for more information: https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
-    # As a workaround, the `Standard` config is committed by default in Ruby 2.7.
-    # Ruby 3.0 and higher use `StandardUncommitted` as `Standard` since they have no issues with `(*args, **kwargs, &block)` delegation.
-    #
-    # For migration purposes, you can control config commitment, by using `StandardUncommitted` and `StandardCommitted` explicitly, for example:
-    #
-    #   class PerformOperation
-    #     include ConvenientService::Configs::Standard
-    #     # ...
-    #   end
-    #
-    # is equivalent to the following in Ruby 2.7
-    #
-    #   class PerformOperation
-    #     include ConvenientService::Configs::StandardCommitted
-    #     # ...
-    #   end
-    #
-    # and in Ruby 3.0+
-    #
-    #   class PerformOperation
-    #     include ConvenientService::Configs::StandardUncommitted
-    #     # ...
-    #     # Trigger `commit_config!` manually or it is automatically triggered by first `method_missing`.
-    #   end
-    #
-    Standard = ::RUBY_VERSION >= "3.0" ? StandardUncommitted : StandardCommitted
   end
 end

--- a/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
+++ b/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
@@ -14,7 +14,7 @@ module ConvenientService
           module Config
             def self.included(service_class)
               service_class.class_exec do
-                include Configs::StandardUncommitted
+                include Configs::Standard
 
                 ##
                 # NOTE: `AssignsAttributesInConstructor::UsingDryInitializer` plugin.
@@ -33,8 +33,6 @@ module ConvenientService
                 middlewares method: :result do
                   use Plugins::Service::HasResultParamsValidations::UsingDryValidation::Middleware
                 end
-
-                commit_config!
               end
             end
           end

--- a/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
+++ b/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
@@ -14,7 +14,7 @@ module ConvenientService
           module Config
             def self.included(service_class)
               service_class.class_exec do
-                include Configs::StandardUncommitted
+                include Configs::Standard
 
                 ##
                 # NOTE: `AssignsAttributesInConstructor::UsingActiveModelAttributeAssignment` plugin.
@@ -44,8 +44,6 @@ module ConvenientService
                 middlewares method: :result do
                   use Plugins::Service::HasResultParamsValidations::UsingActiveModelValidations::Middleware
                 end
-
-                commit_config!
               end
             end
           end

--- a/lib/convenient_service/utils/method.rb
+++ b/lib/convenient_service/utils/method.rb
@@ -2,6 +2,7 @@
 
 require_relative "method/defined"
 require_relative "method/find_own"
+require_relative "method/find_own_from_class"
 
 module ConvenientService
   module Utils
@@ -14,8 +15,12 @@ module ConvenientService
           Defined.call(method_name, **kwargs)
         end
 
-        def find_own(method_name, object, **kwargs)
-          FindOwn.call(method_name, object, **kwargs)
+        def find_own(method_name, instance, **kwargs)
+          FindOwn.call(method_name, instance, **kwargs)
+        end
+
+        def find_own_from_class(method_name, klass, **kwargs)
+          FindOwnFromClass.call(method_name, klass, **kwargs)
         end
       end
     end

--- a/lib/convenient_service/utils/method/find_own.rb
+++ b/lib/convenient_service/utils/method/find_own.rb
@@ -6,20 +6,22 @@ module ConvenientService
       class FindOwn < Support::Command
         include Support::FiniteLoop
 
-        attr_reader :method_name, :object, :max_iteration_count
+        attr_reader :method_name, :instance, :max_iteration_count
 
-        def initialize(method_name, object, max_iteration_count: Support::FiniteLoop::MAX_ITERATION_COUNT)
+        def initialize(method_name, instance, max_iteration_count: Support::FiniteLoop::MAX_ITERATION_COUNT)
           @method_name = method_name
-          @object = object
+          @instance = instance
           @max_iteration_count = max_iteration_count
         end
 
         def call
-          method = object.method(method_name) if object.respond_to?(method_name)
+          # method = instance.method(method_name) if instance.respond_to?(method_name, true)
+
+          method = instance.method(method_name) if instance.respond_to?(method_name)
 
           finite_loop do
             break if method.nil?
-            break if method.owner == object.class
+            break if method.owner == instance.class
 
             method = method.super_method
           end

--- a/lib/convenient_service/utils/method/find_own_from_class.rb
+++ b/lib/convenient_service/utils/method/find_own_from_class.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+##
+# @example
+#   ConvenientService::Utils::Method::FindOwnFromClass
+#
+module ConvenientService
+  module Utils
+    module Method
+      class FindOwnFromClass < Support::Command
+        include Support::FiniteLoop
+
+        attr_reader :method_name, :klass, :max_iteration_count
+
+        def initialize(method_name, klass, max_iteration_count: Support::FiniteLoop::MAX_ITERATION_COUNT)
+          @method_name = method_name
+          @klass = klass
+          @max_iteration_count = max_iteration_count
+        end
+
+        def call
+          method = klass.instance_method(method_name) if klass.instance_methods(false).include?(method_name) || klass.private_instance_methods(false).include?(method_name)
+
+          finite_loop do
+            break if method.nil?
+            break if method.owner == klass
+
+            method = method.super_method
+          end
+
+          method
+        end
+
+        private
+
+        def finite_loop(&block)
+          super(max_iteration_count: max_iteration_count, &block)
+        end
+      end
+    end
+  end
+end
+
+# self.class.ancestors.drop_while { |mod| mod != self.class::InstanceMethodsMiddlewaresCallers }.drop(1).find { |mod| mod.instance_methods(false).include?(method) || mod.private_instance_methods(false).include?(method) }.then { |mod| ConvenientService::Utils::Method.find_own_from_class(method, mod) }

--- a/spec/lib/convenient_service/configs/aliases_spec.rb
+++ b/spec/lib/convenient_service/configs/aliases_spec.rb
@@ -7,7 +7,5 @@ require "convenient_service"
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "convenient_service/configs/aliases" do
   specify { expect(ConvenientService::Standard::Config).to eq(ConvenientService::Configs::Standard) }
-  specify { expect(ConvenientService::Standard::CommittedConfig).to eq(ConvenientService::Configs::StandardCommitted) }
-  specify { expect(ConvenientService::Standard::UncommittedConfig).to eq(ConvenientService::Configs::StandardUncommitted) }
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
Check [this gist](https://gist.github.com/marian13/9c25041f835564e945d978839097d419) for more info. This is a very simplified example, but a similar logic is at the heart of this library.

| | |
| - | - |
| **Before** | This PR |
| **After:** | https://github.com/marian13/convenient_service/pull/3 |

