### PR TITLE
CS-2: Rename Utils::Module.find_own_const to Utils::Module.get_own_const

### DIFF
--- a/lib/convenient_service/common/plugins/has_internals/commands/create_internals_class.rb
+++ b/lib/convenient_service/common/plugins/has_internals/commands/create_internals_class.rb
@@ -46,7 +46,7 @@ module ConvenientService
             private
 
             def internals_class
-              @internals_class ||= Utils::Module.find_own_const(service_class, :Internals) || ::Class.new(Entities::Internals)
+              @internals_class ||= Utils::Module.get_own_const(service_class, :Internals) || ::Class.new(Entities::Internals)
             end
           end
         end

--- a/lib/convenient_service/service/plugins/has_result/commands/create_result_class.rb
+++ b/lib/convenient_service/service/plugins/has_result/commands/create_result_class.rb
@@ -46,7 +46,7 @@ module ConvenientService
             private
 
             def result_class
-              @result_class ||= Utils::Module.find_own_const(service_class, :Result) || ::Class.new(Entities::Result)
+              @result_class ||= Utils::Module.get_own_const(service_class, :Result) || ::Class.new(Entities::Result)
             end
           end
         end

--- a/lib/convenient_service/service/plugins/has_result_steps/commands/create_step_class.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/commands/create_step_class.rb
@@ -50,7 +50,7 @@ module ConvenientService
             private
 
             def step_class
-              @step_class ||= Utils::Module.find_own_const(service_class, :Step) || ::Class.new(Entities::Step)
+              @step_class ||= Utils::Module.get_own_const(service_class, :Step) || ::Class.new(Entities::Step)
             end
           end
         end

--- a/lib/convenient_service/utils/module.rb
+++ b/lib/convenient_service/utils/module.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "module/get_own_instance_method"
-require_relative "module/find_own_const"
+require_relative "module/get_own_const"
 require_relative "module/has_own_instance_method"
 
 module ConvenientService
@@ -29,11 +29,11 @@ module ConvenientService
         # @return [Object] Value of own const. Can be any type.
         #
         # @example:
-        #   ConvenientService::Utils::Module.find_own_const(Object, :File)
-        #   ConvenientService::Utils::Module.find_own_const(Class, :File)
+        #   ConvenientService::Utils::Module.get_own_const(Object, :File)
+        #   ConvenientService::Utils::Module.get_own_const(Class, :File)
         #
-        def find_own_const(mod, const_name)
-          FindOwnConst.call(mod, const_name)
+        def get_own_const(mod, const_name)
+          GetOwnConst.call(mod, const_name)
         end
 
         ##

--- a/lib/convenient_service/utils/module/get_own_const.rb
+++ b/lib/convenient_service/utils/module/get_own_const.rb
@@ -5,7 +5,7 @@
 #   module Test
 #   end
 #
-#   ConvenientService::Utils::Module::FindOwnConst.call(Test, :File)
+#   ConvenientService::Utils::Module::GetOwnConst.call(Test, :File)
 #   # => nil, not File from Ruby Core.
 #
 #   module Test
@@ -13,13 +13,13 @@
 #     end
 #   end
 #
-#   ConvenientService::Utils::Module::FindOwnConst.call(Test, :File)
+#   ConvenientService::Utils::Module::GetOwnConst.call(Test, :File)
 #   # => Test::File
 #
 module ConvenientService
   module Utils
     module Module
-      class FindOwnConst < Support::Command
+      class GetOwnConst < Support::Command
         ##
         # @!attribute [r] mod
         #   @return [Class, Module]

--- a/spec/lib/convenient_service/utils/module_spec.rb
+++ b/spec/lib/convenient_service/utils/module_spec.rb
@@ -6,8 +6,8 @@ require "convenient_service"
 
 # rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
 RSpec.describe ConvenientService::Utils::Module do
-  describe ".find_own_const" do
-    let(:result) { described_class.find_own_const(mod, const_name) }
+  describe ".get_own_const" do
+    let(:result) { described_class.get_own_const(mod, const_name) }
 
     let(:mod) { Class.new }
 


### PR DESCRIPTION
## What was done as part of this PR?

- Renamed `Utils::Module.find_own_const` to `Utils::Module.get_own_const`.

## Why it was done?

- To make it similar to [Module/const_get](https://apidock.com/ruby/v2_5_5/Module/const_get).

## How to test?

-  https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests
   
## Examples

- ```ruby
   module Test
   end
   
   Test.const_get(:File)
   # => File, from Ruby Core.

   ConvenientService::Utils::Module::GetOwnConst.call(Test, :File)
   # => nil, not File from Ruby Core.

   module Test
     class File
     end
   end
   
   Test.const_get(:File)
   # => Test::File

   ConvenientService::Utils::Module::GetOwnConst.call(Test, :File)
   # => Test::File
   ```

## Glossary

- `Own` (in the context of this lib) means defined in the context of the calling class, not from the whole hierarchy. 
