### PR TITLE
CS-4: Implement `respond_to_missing?` in Core::ClassMethods

### DIFF
--- a/lib/convenient_service/core/class_methods.rb
+++ b/lib/convenient_service/core/class_methods.rb
@@ -127,6 +127,26 @@ module ConvenientService
         middlewares(scope: :class).values.each(&:define!)
       end
 
+      ##
+      # @see https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding
+      # @see https://stackoverflow.com/a/3304683/12201472
+      #
+      # @param method_name [Symbol, String]
+      # @param include_private [Boolean]
+      # @return [Boolean]
+      #
+      def respond_to_missing?(method_name, include_private = false)
+        return true if self.singleton_class.method_defined?(method_name)
+        return true if concerns.class_method_defined?(method_name)
+
+        if include_private
+          return true if self.singleton_class.private_method_defined?(method_name)
+          return true if concerns.private_class_method_defined?(method_name)
+        end
+
+        false
+      end
+
       private
 
       ##
@@ -150,16 +170,6 @@ module ConvenientService
         ConvenientService.logger.debug { "[Core] Included concerns into `#{self}` | Triggered by `method_missing` | Method: `.#{method}`" }
 
         __send__(method, *args, **kwargs, &block)
-      end
-
-      ##
-      # TODO: How?
-      #
-      # TODO: Implement.
-      # https://thoughtbot.com/blog/always-define-respond-to-missing-when-overriding
-      #
-      def respond_to_missing?(method_name, include_private = false)
-        false
       end
     end
   end

--- a/lib/convenient_service/core/class_methods.rb
+++ b/lib/convenient_service/core/class_methods.rb
@@ -136,11 +136,11 @@ module ConvenientService
       # @return [Boolean]
       #
       def respond_to_missing?(method_name, include_private = false)
-        return true if self.singleton_class.method_defined?(method_name)
+        return true if singleton_class.method_defined?(method_name)
         return true if concerns.class_method_defined?(method_name)
 
         if include_private
-          return true if self.singleton_class.private_method_defined?(method_name)
+          return true if singleton_class.private_method_defined?(method_name)
           return true if concerns.private_class_method_defined?(method_name)
         end
 

--- a/lib/convenient_service/core/entities/concerns.rb
+++ b/lib/convenient_service/core/entities/concerns.rb
@@ -18,9 +18,9 @@ module ConvenientService
         # @param method_name [Symbol, String]
         # @return [Boolean]
         #
-        def method_defined?(method_name)
-          return true if method_defined_in_instance_methods_modules?(method_name)
-          return true if method_defined_directly?(method_name)
+        def instance_method_defined?(method_name)
+          return true if instance_method_defined_in_instance_methods_modules?(method_name)
+          return true if instance_method_defined_directly?(method_name)
 
           false
         end
@@ -29,11 +29,27 @@ module ConvenientService
         # @param method_name [Symbol, String]
         # @return [Boolean]
         #
-        def private_method_defined?(method_name)
-          return true if private_method_defined_in_instance_methods_modules?(method_name)
-          return true if private_method_defined_directly?(method_name)
+        def private_instance_method_defined?(method_name)
+          return true if private_instance_method_defined_in_instance_methods_modules?(method_name)
+          return true if private_instance_method_defined_directly?(method_name)
 
           false
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def class_method_defined?(method_name)
+          class_method_defined_in_class_methods_modules?(method_name)
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def private_class_method_defined?(method_name)
+          private_class_method_defined_in_class_methods_modules?(method_name)
         end
 
         ##
@@ -105,23 +121,7 @@ module ConvenientService
         # @param method_name [Symbol, String]
         # @return [Boolean]
         #
-        def method_defined_in_instance_methods_modules?(method_name)
-          instance_methods_modules.any? { |mod| mod.method_defined?(method_name) }
-        end
-
-        ##
-        # @param method_name [Symbol, String]
-        # @return [Boolean]
-        #
-        def private_method_defined_in_instance_methods_modules?(method_name)
-          instance_methods_modules.any? { |mod| mod.private_method_defined?(method_name) }
-        end
-
-        ##
-        # @param method_name [Symbol, String]
-        # @return [Boolean]
-        #
-        def method_defined_directly?(method_name)
+        def instance_method_defined_directly?(method_name)
           plain_concerns.any? { |concern| concern.method_defined?(method_name) }
         end
 
@@ -129,8 +129,40 @@ module ConvenientService
         # @param method_name [Symbol, String]
         # @return [Boolean]
         #
-        def private_method_defined_directly?(method_name)
+        def private_instance_method_defined_directly?(method_name)
           plain_concerns.any? { |concern| concern.private_method_defined?(method_name) }
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def instance_method_defined_in_instance_methods_modules?(method_name)
+          instance_methods_modules.any? { |mod| mod.method_defined?(method_name) }
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def private_instance_method_defined_in_instance_methods_modules?(method_name)
+          instance_methods_modules.any? { |mod| mod.private_method_defined?(method_name) }
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def class_method_defined_in_class_methods_modules?(method_name)
+          class_methods_modules.any? { |mod| mod.method_defined?(method_name) }
+        end
+
+        ##
+        # @param method_name [Symbol, String]
+        # @return [Boolean]
+        #
+        def private_class_method_defined_in_class_methods_modules?(method_name)
+          class_methods_modules.any? { |mod| mod.private_method_defined?(method_name) }
         end
 
         ##
@@ -140,6 +172,15 @@ module ConvenientService
           plain_concerns
             .select { |concern| concern.const_defined?(:InstanceMethods, false) }
             .map { |concern| concern.const_get(:InstanceMethods) }
+        end
+
+        ##
+        # @return [Array<Module>]
+        #
+        def class_methods_modules
+          plain_concerns
+            .select { |concern| concern.const_defined?(:ClassMethods, false) }
+            .map { |concern| concern.const_get(:ClassMethods) }
         end
 
         ##

--- a/lib/convenient_service/core/instance_methods.rb
+++ b/lib/convenient_service/core/instance_methods.rb
@@ -29,11 +29,11 @@ module ConvenientService
       #
       def respond_to_missing?(method_name, include_private = false)
         return true if self.class.method_defined?(method_name)
-        return true if concerns.method_defined?(method_name)
+        return true if concerns.instance_method_defined?(method_name)
 
         if include_private
           return true if self.class.private_method_defined?(method_name)
-          return true if concerns.private_method_defined?(method_name)
+          return true if concerns.private_instance_method_defined?(method_name)
         end
 
         false

--- a/spec/lib/convenient_service/core/class_methods_spec.rb
+++ b/spec/lib/convenient_service/core/class_methods_spec.rb
@@ -5,56 +5,10 @@ require "spec_helper"
 require "convenient_service"
 
 # rubocop:disable RSpec/NestedGroups
-RSpec.describe ConvenientService::Core::InstanceMethods do
+RSpec.describe ConvenientService::Core::ClassMethods do
   include ConvenientService::RSpec::Matchers::DelegateTo
 
   let(:service_instance) { service_class.new }
-
-  describe "#concerns" do
-    let(:service_class) do
-      Class.new.tap do |klass|
-        klass.class_exec(described_class, concerns_result) do |mod, concerns_result|
-          include mod
-
-          define_singleton_method(:concerns) { |&block| concerns_result }
-        end
-      end
-    end
-
-    let(:service_instance) { service_class.new }
-    let(:concerns_result) { double }
-    let(:configuration_block) { proc {} }
-
-    specify {
-      expect { service_instance.concerns(&configuration_block) }
-        .to delegate_to(service_class, :concerns)
-        .with_arguments(&configuration_block)
-        .and_return_its_value
-    }
-  end
-
-  describe "#middlewares" do
-    let(:service_class) do
-      Class.new.tap do |klass|
-        klass.class_exec(described_class, middlewares_result) do |mod, middlewares_result|
-          include mod
-
-          define_singleton_method(:middlewares) { |**kwargs, &block| middlewares_result }
-        end
-      end
-    end
-
-    let(:middlewares_result) { double }
-    let(:kwargs) { {foo: :bar} }
-    let(:configuration_block) { proc {} }
-
-    specify {
-      expect { service_instance.middlewares(**kwargs, &configuration_block) }
-        .to delegate_to(service_class, :middlewares)
-        .with_arguments(**kwargs, &configuration_block)
-        .and_return_its_value
-    }
-  end
 
   describe "#method_missing" do
     let(:service_class) do
@@ -63,13 +17,16 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
 
         concerns do
           ##
-          # NOTE: Simplest concern is just a module.
-          # NOTE: Defines `foo` that is later included by service class by `concerns.include!`.
+          # NOTE: Defines `foo` that is later extended by service class by `concerns.include!`.
           #
           concern =
             Module.new do
-              def foo(*args, **kwargs, &block)
-                [:foo, args, kwargs, block&.source_location]
+              include ConvenientService::Support::Concern
+
+              class_methods do
+                def foo(*args, **kwargs, &block)
+                  [:foo, args, kwargs, block&.source_location]
+                end
               end
             end
 
@@ -86,7 +43,7 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
       ##
       # NOTE: Intentionally calling missed method. But later it is added by `concerns.include!`.
       #
-      expect { service_instance.foo }.to delegate_to(service_instance.concerns, :include!)
+      expect { service_class.foo }.to delegate_to(service_class.concerns, :include!)
     end
 
     ##
@@ -97,28 +54,28 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
       ##
       # NOTE: If `[:foo, args, kwargs, block&.source_location]` is returned, then `super` was called. See concern above.
       #
-      expect(service_instance.foo(*args, **kwargs, &block)).to eq([:foo, args, kwargs, block&.source_location])
+      expect(service_class.foo(*args, **kwargs, &block)).to eq([:foo, args, kwargs, block&.source_location])
     end
 
-    context "when concerns are included more than once (since they do not contain required instance method)" do
+    context "when concerns are included more than once (since they do not contain required class method)" do
       it "raises `NoMethodError`" do
         ##
         # NOTE: Intentionally calling missed method that won't be included even by concern.
         #
-        expect { service_instance.bar }.to raise_error(NoMethodError)
+        expect { service_class.bar }.to raise_error(NoMethodError)
       end
     end
   end
 
   describe "#respond_to_missing?" do
     let(:method_name) { :foo }
-    let(:result) { service_instance.respond_to_missing?(method_name, include_private) }
+    let(:result) { service_class.respond_to_missing?(method_name, include_private) }
 
     context "when `include_private` is `false`" do
       let(:include_private) { false }
 
-      context "when service class does NOT have public instance method" do
-        context "when concerns do NOT have public instance method" do
+      context "when service class does NOT have public class method" do
+        context "when concerns do NOT have public class method" do
           let(:service_class) do
             Class.new do
               include ConvenientService::Core
@@ -129,14 +86,16 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
             expect(result).to eq(false)
           end
 
-          context "when service class has private instance method" do
+          context "when service class has private class method" do
             let(:service_class) do
               Class.new do
                 include ConvenientService::Core
 
-                private
+                class << self
+                  private
 
-                def foo
+                  def foo
+                  end
                 end
               end
             end
@@ -146,16 +105,20 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
             end
           end
 
-          context "when concerns have private instance method" do
+          context "when concerns have private class method" do
             let(:service_class) do
               Class.new do
                 include ConvenientService::Core
 
                 concerns do
                   concern = Module.new do
-                    private
+                    include ConvenientService::Support::Concern
 
-                    def foo
+                    class_methods do
+                      private
+
+                      def foo
+                      end
                     end
                   end
 
@@ -170,14 +133,18 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
           end
         end
 
-        context "when concerns have public instance method" do
+        context "when concerns have public class method" do
           let(:service_class) do
             Class.new do
               include ConvenientService::Core
 
               concerns do
                 concern = Module.new do
-                  def foo
+                  include ConvenientService::Support::Concern
+
+                  class_methods do
+                    def foo
+                    end
                   end
                 end
 
@@ -197,7 +164,9 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
           Class.new do
             include ConvenientService::Core
 
-            def foo
+            class << self
+              def foo
+              end
             end
           end
         end
@@ -211,8 +180,8 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
     context "when `include_private` is `true`" do
       let(:include_private) { true }
 
-      context "when service class does NOT have public instance method" do
-        context "when concerns do NOT have public instance method" do
+      context "when service class does NOT have public class method" do
+        context "when concerns do NOT have public class method" do
           let(:service_class) do
             Class.new do
               include ConvenientService::Core
@@ -223,14 +192,16 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
             expect(result).to eq(false)
           end
 
-          context "when service class has private instance method" do
+          context "when service class has private class method" do
             let(:service_class) do
               Class.new do
                 include ConvenientService::Core
 
-                private
+                class << self
+                  private
 
-                def foo
+                  def foo
+                  end
                 end
               end
             end
@@ -240,16 +211,20 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
             end
           end
 
-          context "when concerns have private instance method" do
+          context "when concerns have private class method" do
             let(:service_class) do
               Class.new do
                 include ConvenientService::Core
 
                 concerns do
                   concern = Module.new do
-                    private
+                    include ConvenientService::Support::Concern
 
-                    def foo
+                    class_methods do
+                      private
+
+                      def foo
+                      end
                     end
                   end
 
@@ -264,14 +239,18 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
           end
         end
 
-        context "when concerns have public instance method" do
+        context "when concerns have public class method" do
           let(:service_class) do
             Class.new do
               include ConvenientService::Core
 
               concerns do
                 concern = Module.new do
-                  def foo
+                  include ConvenientService::Support::Concern
+
+                  class_methods do
+                    def foo
+                    end
                   end
                 end
 
@@ -291,7 +270,9 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
           Class.new do
             include ConvenientService::Core
 
-            def foo
+            class << self
+              def foo
+              end
             end
           end
         end
@@ -309,9 +290,11 @@ RSpec.describe ConvenientService::Core::InstanceMethods do
         Class.new do
           include ConvenientService::Core
 
-          private
+          class << self
+            private
 
-          def foo
+            def foo
+            end
           end
         end
       end


### PR DESCRIPTION
## What was done as a part of this PR?

- Implemented `respond_to_missing?` in `Core::ClassMethods`.

## How to test?

- https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests