### PR TITLE
CS-7: Use three dots whenever possible

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,13 +27,9 @@ inherit_gem:
 
 AllCops:
   ##
-  # NOTE: `TargetRubyVersion: 2.5` is the oldest supported Ruby version by Rubocop.
-  # As a result, Rubocop may miss incompatible code with Ruby 2.3 and Ruby 2.4, but it will be caught by specs (if they are written of course).
   # https://github.com/testdouble/standard#how-do-i-specify-a-ruby-version-what-is-supported
   #
-  # TODO: Update when support for Rubies lower than 2.5 will be dropped.
-  #
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
   Exclude:
     ##

--- a/lib/convenient_service/common/plugins/caches_return_value/middleware.rb
+++ b/lib/convenient_service/common/plugins/caches_return_value/middleware.rb
@@ -5,15 +5,6 @@ module ConvenientService
     module Plugins
       module CachesReturnValue
         class Middleware < Core::MethodChainMiddleware
-          ##
-          # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-          #
-          #   def next(...)
-          #     # ...
-          #
-          #     entity.internals.cache.fetch(key) { chain.next(...) }
-          #   end
-          #
           def next(*args, **kwargs, &block)
             key = Entities::Key.new(method: method, args: args, kwargs: kwargs, block: block)
 

--- a/lib/convenient_service/common/plugins/has_around_callbacks/middleware.rb
+++ b/lib/convenient_service/common/plugins/has_around_callbacks/middleware.rb
@@ -5,7 +5,7 @@ module ConvenientService
     module Plugins
       module HasAroundCallbacks
         class Middleware < Core::MethodChainMiddleware
-          def next(*args, **kwargs, &block)
+          def next(...)
             ##
             # A variable that stores return value of middleware `chain.next` aka `original_value`.
             # It is reassigned later by the `initial_around_callback`.
@@ -22,7 +22,7 @@ module ConvenientService
             #
             initial_around_callback = Plugins::HasCallbacks::Entities::Callback.new(
               types: [:around, method],
-              block: proc { original_value = chain.next(*args, **kwargs, &block) }
+              block: proc { original_value = chain.next(...) }
             )
 
             ##

--- a/lib/convenient_service/common/plugins/has_callbacks/middleware.rb
+++ b/lib/convenient_service/common/plugins/has_callbacks/middleware.rb
@@ -5,10 +5,10 @@ module ConvenientService
     module Plugins
       module HasCallbacks
         class Middleware < Core::MethodChainMiddleware
-          def next(*args, **kwargs, &block)
+          def next(...)
             entity.callbacks.for([:before, method]).each { |callback| callback.call_in_context(entity) }
 
-            original_value = chain.next(*args, **kwargs, &block)
+            original_value = chain.next(...)
 
             entity.callbacks.for([:after, method]).reverse_each { |callback| callback.call_in_context(entity, original_value) }
 

--- a/lib/convenient_service/common/plugins/has_constructor/concern.rb
+++ b/lib/convenient_service/common/plugins/has_constructor/concern.rb
@@ -8,7 +8,7 @@ module ConvenientService
           include Support::Concern
 
           instance_methods do
-            def initialize(*args, **kwargs, &block)
+            def initialize(...)
             end
           end
         end

--- a/lib/convenient_service/core/instance_methods.rb
+++ b/lib/convenient_service/core/instance_methods.rb
@@ -15,8 +15,8 @@ module ConvenientService
       # @param (see ConvenientService::Core::ClassMethods#middlewares)
       # @return [ConvenientService::Core::Entities::MethodMiddlewares]
       #
-      def middlewares(*args, **kwargs, &block)
-        self.class.middlewares(*args, **kwargs, &block)
+      def middlewares(...)
+        self.class.middlewares(...)
       end
 
       ##

--- a/lib/convenient_service/rspec/helpers/ignoring_error.rb
+++ b/lib/convenient_service/rspec/helpers/ignoring_error.rb
@@ -4,8 +4,8 @@ module ConvenientService
   module RSpec
     module Helpers
       module IgnoringError
-        def ignoring_error(*errors, &block)
-          Custom::IgnoringError.call(*errors, &block)
+        def ignoring_error(...)
+          Custom::IgnoringError.call(...)
         end
       end
     end

--- a/lib/convenient_service/service/plugins/has_result/concern/class_methods.rb
+++ b/lib/convenient_service/service/plugins/has_result/concern/class_methods.rb
@@ -7,11 +7,10 @@ module ConvenientService
         module Concern
           module ClassMethods
             ##
-            # NOTE: Update to `def result(...)` when support for Rubies lower than 2.7 is dropped.
-            # https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArgumentsForwarding
             #
-            def result(*args, **kwargs, &block)
-              new(*args, **kwargs, &block).result
+            #
+            def result(...)
+              new(...).result
             end
 
             ##

--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/marks_result_status_as_checked/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/marks_result_status_as_checked/middleware.rb
@@ -9,19 +9,10 @@ module ConvenientService
             module Plugins
               module MarksResultStatusAsChecked
                 class Middleware < Core::MethodChainMiddleware
-                  ##
-                  # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-                  #
-                  #   def next(*args, **kwargs, &block)
-                  #     # ...
-                  #
-                  #     chain.next(*args, **kwargs, &block)
-                  #   end
-                  #
-                  def next(*args, **kwargs, &block)
+                  def next(...)
                     entity.internals.cache[:has_checked_status] = true
 
-                    chain.next(*args, **kwargs, &block)
+                    chain.next(...)
                   end
                 end
               end

--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/raises_on_not_checked_result_status/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/raises_on_not_checked_result_status/middleware.rb
@@ -9,19 +9,10 @@ module ConvenientService
             module Plugins
               module RaisesOnNotCheckedResultStatus
                 class Middleware < Core::MethodChainMiddleware
-                  ##
-                  # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-                  #
-                  #   def next(*args, **kwargs, &block)
-                  #     # ...
-                  #
-                  #     chain.next(*args, **kwargs, &block)
-                  #   end
-                  #
-                  def next(*args, **kwargs, &block)
+                  def next(...)
                     assert_has_checked_status!
 
-                    chain.next(*args, **kwargs, &block)
+                    chain.next(...)
                   end
 
                   private

--- a/lib/convenient_service/service/plugins/has_result/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result/middleware.rb
@@ -5,8 +5,8 @@ module ConvenientService
     module Plugins
       module HasResult
         class Middleware < Core::MethodChainMiddleware
-          def next(*args, **kwargs, &block)
-            original_result = chain.next(*args, **kwargs, &block)
+          def next(...)
+            original_result = chain.next(...)
 
             return original_result if original_result.class.include?(Entities::Result::Concern)
 

--- a/lib/convenient_service/service/plugins/has_result_params_validations/using_active_model_validations/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_params_validations/using_active_model_validations/middleware.rb
@@ -6,19 +6,10 @@ module ConvenientService
       module HasResultParamsValidations
         module UsingActiveModelValidations
           class Middleware < Core::MethodChainMiddleware
-            ##
-            # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-            #
-            #   def next(...)
-            #     # ...
-            #
-            #     chain.next(...)
-            #   end
-            #
-            def next(*args, **kwargs, &block)
+            def next(...)
               return entity.failure(data: errors) if errors.any?
 
-              chain.next(*args, **kwargs, &block)
+              chain.next(...)
             end
 
             private

--- a/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
@@ -6,19 +6,10 @@ module ConvenientService
       module HasResultParamsValidations
         module UsingDryValidation
           class Middleware < Core::MethodChainMiddleware
-            ##
-            # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-            #
-            #   def next(...)
-            #     # ...
-            #
-            #     chain.next(...)
-            #   end
-            #
-            def next(*args, **kwargs, &block)
+            def next(...)
               return entity.failure(data: errors) if errors.any?
 
-              chain.next(*args, **kwargs, &block)
+              chain.next(...)
             end
 
             private

--- a/lib/convenient_service/service/plugins/has_result_steps/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/middleware.rb
@@ -5,19 +5,8 @@ module ConvenientService
     module Plugins
       module HasResultSteps
         class Middleware < Core::MethodChainMiddleware
-          ##
-          # TODO: Specs.
-          #
-          # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-          #
-          #   def next(*args, **kwargs, &block)
-          #     return chain.next(*args, **kwargs, &block) if entity.steps.none?
-          #
-          #     # ...
-          #   end
-          #
-          def next(*args, **kwargs, &block)
-            return chain.next(*args, **kwargs, &block) if entity.steps.none?
+          def next(...)
+            return chain.next(...) if entity.steps.none?
 
             last_step.result
           end

--- a/lib/convenient_service/service/plugins/raises_on_double_result/middleware.rb
+++ b/lib/convenient_service/service/plugins/raises_on_double_result/middleware.rb
@@ -5,19 +5,10 @@ module ConvenientService
     module Plugins
       module RaisesOnDoubleResult
         class Middleware < Core::MethodChainMiddleware
-          ##
-          # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-          #
-          #   def next(...)
-          #     # ...
-          #
-          #     chain.next(...)
-          #   end
-          #
-          def next(*args, **kwargs, &block)
+          def next(...)
             refute_has_result! || mark_as_has_result!
 
-            chain.next(*args, **kwargs, &block)
+            chain.next(...)
           end
 
           private

--- a/lib/convenient_service/service/plugins/wraps_result_in_db_transaction/middleware.rb
+++ b/lib/convenient_service/service/plugins/wraps_result_in_db_transaction/middleware.rb
@@ -5,14 +5,8 @@ module ConvenientService
     module Plugins
       module WrapsResultInDbTransaction
         class Middleware < Core::MethodChainMiddleware
-          # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-          #
-          #   def next(...)
-          #     ::ActiveRecord::Base.transaction { chain.next(...) }
-          #   end
-          #
-          def next(*args, **kwargs, &block)
-            ::ActiveRecord::Base.transaction { chain.next(*args, **kwargs, &block) }
+          def next(...)
+            ::ActiveRecord::Base.transaction { chain.next(...) }
           end
         end
       end

--- a/lib/convenient_service/support/castable.rb
+++ b/lib/convenient_service/support/castable.rb
@@ -13,12 +13,12 @@ module ConvenientService
       instance_methods do
         private
 
-        def cast(other, **options)
-          self.class.cast(other, **options)
+        def cast(...)
+          self.class.cast(...)
         end
 
-        def cast!(other, **options)
-          self.class.cast!(other, **options)
+        def cast!(...)
+          self.class.cast!(...)
         end
       end
 

--- a/lib/convenient_service/support/command.rb
+++ b/lib/convenient_service/support/command.rb
@@ -10,14 +10,8 @@ module ConvenientService
         ##
         # TODO: Specs.
         #
-        # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-        #
-        #   def call(...)
-        #     new(...).call
-        #   end
-        #
-        def call(*args, **kwargs, &block)
-          new(*args, **kwargs, &block).call
+        def call(...)
+          new(...).call
         end
       end
 

--- a/spec/lib/convenient_service/core/class_methods_spec.rb
+++ b/spec/lib/convenient_service/core/class_methods_spec.rb
@@ -111,16 +111,16 @@ RSpec.describe ConvenientService::Core::ClassMethods do
     context "when `configuration_block` is passed" do
       let(:instance_method_middleware) do
         Class.new(ConvenientService::Core::MethodChainMiddleware) do
-          def next(*args, **kwargs, &block)
-            chain.next(*args, **kwargs, &block)
+          def next(...)
+            chain.next(...)
           end
         end
       end
 
       let(:class_method_middleware) do
         Class.new(ConvenientService::Core::MethodChainMiddleware) do
-          def next(*args, **kwargs, &block)
-            chain.next(*args, **kwargs, &block)
+          def next(...)
+            chain.next(...)
           end
         end
       end

--- a/spec/lib/convenient_service/rspec/matchers/custom/delegate_to_spec.rb
+++ b/spec/lib/convenient_service/rspec/matchers/custom/delegate_to_spec.rb
@@ -59,15 +59,8 @@ RSpec.describe ConvenientService::RSpec::Matchers::Custom::DelegateTo do
 
       let(:klass) do
         Class.new do
-          ##
-          # TODO: Replace to the following when support for Rubies lower than 2.7 is dropped.
-          #
-          #   def foo(...)
-          #     bar(...)
-          #   end
-          #
-          def foo(*args, **kwargs, &block)
-            bar(*args, **kwargs, &block)
+          def foo(...)
+            bar(...)
           end
 
           def bar(*args, **kwargs, &block)


### PR DESCRIPTION
## What was done as a part of this PR?

- Used three dots instead of `*args, **kwargs, &block` whenever possible.