### PR TITLE
CS-Y: Update conjunction return value when no procs are given

### DIFF
--- a/lib/convenient_service/utils/proc/conjunct.rb
+++ b/lib/convenient_service/utils/proc/conjunct.rb
@@ -29,7 +29,7 @@ module ConvenientService
         # - https://en.wikipedia.org/wiki/Logical_conjunction
         #
         def call
-          return ->(item) { false } if procs.none?
+          return ->(item) { true } if procs.none?
 
           return procs.first if procs.one?
 

--- a/spec/lib/convenient_service/utils/proc/conjunct_spec.rb
+++ b/spec/lib/convenient_service/utils/proc/conjunct_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe ConvenientService::Utils::Proc::Conjunct do
     context "when procs array is empty" do
       let(:procs) { [] }
 
-      it "returns proc that always evaluates to false" do
-        expect(conjuction[item]).to eq(false)
+      it "returns proc that always evaluates to true" do
+        expect(conjuction[item]).to eq(true)
       end
     end
 


### PR DESCRIPTION
## What was done as a part of this PR?

- Changed the return value of `Utils::Proc.conjunct` to true when no procs are given

## Why it was done?

- Since ['Everything which is not forbidden is allowed'](https://en.wikipedia.org/wiki/Everything_which_is_not_forbidden_is_allowed)

- In mathematics and logic, a [vacuous truth](https://en.wikipedia.org/wiki/Vacuous_truth) is a conditional or universal statement (a universal statement that can be converted to a conditional statement) that is true because the antecedent cannot be satisfied.

## How to test?

- task rspec -- spec/lib/convenient_service/utils/proc/conjunct_spec.rb:14