### PR TITLE
CS-17: Change `delegate_to` default behaviour from `exactly once` to `at least once`

### DIFF
--- a/lib/convenient_service/rspec/matchers/custom/cache_its_value.rb
+++ b/lib/convenient_service/rspec/matchers/custom/cache_its_value.rb
@@ -23,26 +23,26 @@ module ConvenientService
           end
 
           def failure_message
-            "expected #{printable_block} to cache its value"
+            "expected #{printable_block_expectation} to cache its value"
           end
 
           def failure_message_when_negated
-            "expected #{printable_block} NOT to cache its value"
+            "expected #{printable_block_expectation} NOT to cache its value"
           end
 
           ##
           # NOTE: An example of how RSpec extracts block source, but they marked it as private.
           # https://github.com/rspec/rspec-expectations/blob/311aaf245f2c5493572bf683b8c441cb5f7e44c8/lib/rspec/matchers/built_in/change.rb#L437
           #
-          # TODO: `printable_block` when `method_source` is available.
+          # TODO: `printable_block_expectation` when `method_source` is available.
           # https://github.com/banister/method_source
           #
-          # def printable_block
-          #   @printable_block ||= block_expectation.source
+          # def printable_block_expectation
+          #   @printable_block_expectation ||= block_expectation.source
           # end
           #
-          def printable_block
-            @printable_block ||= "{ ... }"
+          def printable_block_expectation
+            @printable_block_expectation ||= "{ ... }"
           end
 
           private


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- The case in the picture is NOT relevant anymore.
  <img width="720" alt="Screenshot 2022-12-04 at 00 57 04" src="https://user-images.githubusercontent.com/22632866/205465587-1e1d740f-47d4-4c54-9260-db0febb28193.png">

- **❗❗❗BREAKING CHANGE❗❗❗:** Now, a spec passes when delegation happens _at least once_, not _exactly once_ as it was before.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- _At least once_ behavior seems more intuitive than _exactly once_.

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- When `with_arguments` is NOT used:
  ```ruby
  expect(object).to have_received(method).at_least(1) unless used_with_arguments?
  ```

- When `with_arguments` is used:
  ```ruby
  ##
  # The following expression is the return of `#matches?`.
  # If it is resolved to `false` then the matcher is not satisfied and the corresponding spec fails.
  #  
  if used_with_arguments?
    actual_arguments_collection.any? do |(actual_args, actual_kwargs, actual_block)|
      actual_args == expected_args && actual_kwargs == expected_kwargs && actual_block == expected_block
    end
  else
    true
  end
  ```

## How to test?

- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Notes
<!--- Additional info, links, screenshots, actually anything that helps to recreate the way of thoughts (optional). -->

- Use plain RSpec if you need _exactly once_ behavior.
- Current `delegate_to` spec suite ❗does NOT fail ❗ when you switch between _at least once_ and _exactly once_ implementations.
- A discussion is created to think about the proper refactoring -  https://github.com/marian13/convenient_service/discussions/27.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
