### PR TITLE
CS-21: Fix status on step

### DIFF
--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods.rb
@@ -49,36 +49,53 @@ module ConvenientService
                     ##
                     # @return [Class]
                     #
-                    def service
-                      internals.cache[:jsend_attributes].service
-                    end
+                    delegate :service, to: :jsend_attributes
 
                     ##
                     # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status]
                     #
-                    def status
-                      internals.cache[:jsend_attributes].status
-                    end
+                    delegate :status, to: :jsend_attributes
+
+                    ##
+                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status]
+                    #
+                    alias_method :unsafe_status, :status
 
                     ##
                     # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data]
                     #
-                    def data
-                      internals.cache[:jsend_attributes].data
-                    end
+                    delegate :data, to: :jsend_attributes
+
+                    ##
+                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data]
+                    #
+                    alias_method :unsafe_data, :data
 
                     ##
                     # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message]
                     #
-                    def message
-                      internals.cache[:jsend_attributes].message
-                    end
+                    delegate :message, to: :jsend_attributes
+
+                    ##
+                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message]
+                    #
+                    alias_method :unsafe_message, :message
 
                     ##
                     # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code]
                     #
-                    def code
-                      internals.cache[:jsend_attributes].code
+                    delegate :code, to: :jsend_attributes
+
+                    ##
+                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code]
+                    #
+                    alias_method :unsafe_code, :code
+
+                    ##
+                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Structs::JSendAttributes]
+                    #
+                    def jsend_attributes
+                      internals.cache[:jsend_attributes]
                     end
 
                     ##
@@ -89,10 +106,10 @@ module ConvenientService
                       return unless other.instance_of?(self.class)
 
                       return false if service.class != other.service.class
-                      return false if status != other.status
-                      return false if data != other.data
-                      return false if message != other.message
-                      return false if code != other.code
+                      return false if unsafe_status != other.unsafe_status
+                      return false if unsafe_data != other.unsafe_data
+                      return false if unsafe_message != other.unsafe_message
+                      return false if unsafe_code != other.unsafe_code
 
                       true
                     end

--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods.rb
@@ -57,11 +57,6 @@ module ConvenientService
                     delegate :status, to: :jsend_attributes
 
                     ##
-                    # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status]
-                    #
-                    alias_method :unsafe_status, :status
-
-                    ##
                     # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data]
                     #
                     delegate :data, to: :jsend_attributes
@@ -106,7 +101,7 @@ module ConvenientService
                       return unless other.instance_of?(self.class)
 
                       return false if service.class != other.service.class
-                      return false if unsafe_status != other.unsafe_status
+                      return false if status != other.status
                       return false if unsafe_data != other.unsafe_data
                       return false if unsafe_message != other.unsafe_message
                       return false if unsafe_code != other.unsafe_code

--- a/lib/convenient_service/service/plugins/has_result_steps/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/middleware.rb
@@ -8,7 +8,7 @@ module ConvenientService
           def next(...)
             return chain.next(...) if entity.steps.none?
 
-            last_step.result
+            last_step.result.copy
           end
 
           private

--- a/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods_spec.rb
@@ -125,16 +125,18 @@ RSpec.describe ConvenientService::Service::Plugins::HasResult::Entities::Result:
     end
 
     describe "#jsend_attributes" do
-      it "returns casted JSend attributes" do
-        expect(result.jsend_attributes).to eq(
-          ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Structs::JSendAttributes.new(
-            service: params[:service],
-            status: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status.cast(params[:status]),
-            data: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data.cast(params[:data]),
-            message: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message.cast(params[:message]),
-            code: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code.cast(params[:code])
-          )
+      let(:jsend_attributes) do
+        ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Structs::JSendAttributes.new(
+          service: params[:service],
+          status: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status.cast(params[:status]),
+          data: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data.cast(params[:data]),
+          message: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message.cast(params[:message]),
+          code: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code.cast(params[:code])
         )
+      end
+
+      it "returns casted JSend attributes" do
+        expect(result.jsend_attributes).to eq(jsend_attributes)
       end
     end
 

--- a/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/concern/instance_methods_spec.rb
@@ -94,15 +94,47 @@ RSpec.describe ConvenientService::Service::Plugins::HasResult::Entities::Result:
       end
     end
 
+    describe "#unsafe_data" do
+      it "returns casted `data`" do
+        expect(result.unsafe_data).to eq(ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data.cast(params[:data]))
+      end
+    end
+
     describe "#message" do
       it "returns casted `message`" do
         expect(result.message).to eq(ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message.cast(params[:message]))
       end
     end
 
+    describe "#unsafe_message" do
+      it "returns casted `message`" do
+        expect(result.unsafe_message).to eq(ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message.cast(params[:message]))
+      end
+    end
+
     describe "#code" do
       it "returns casted `code`" do
         expect(result.code).to eq(ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code.cast(params[:code]))
+      end
+    end
+
+    describe "#unsafe_code" do
+      it "returns casted `code`" do
+        expect(result.unsafe_code).to eq(ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code.cast(params[:code]))
+      end
+    end
+
+    describe "#jsend_attributes" do
+      it "returns casted JSend attributes" do
+        expect(result.jsend_attributes).to eq(
+          ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Structs::JSendAttributes.new(
+            service: params[:service],
+            status: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Status.cast(params[:status]),
+            data: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Data.cast(params[:data]),
+            message: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Message.cast(params[:message]),
+            code: ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Entities::Code.cast(params[:code])
+          )
+        )
       end
     end
 

--- a/spec/lib/convenient_service/service/plugins/has_result_steps/middleware_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_steps/middleware_spec.rb
@@ -195,7 +195,11 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Middleware d
         end
 
         it "returns result of intermediate step" do
-          expect(method_value.message).to eq("some error message")
+          expect(method_value).to eq(service_instance.steps.select(&:completed?).last.result)
+        end
+
+        it "copies result of intermediate step" do
+          expect(method_value.object_id).not_to eq(service_instance.steps.select(&:completed?).last.result.object_id)
         end
 
         it "does NOT evaluate results of following steps" do
@@ -324,7 +328,11 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Middleware d
         end
 
         it "returns result of last step" do
-          expect(method_value.data).to eq({baz: :qux})
+          expect(method_value).to eq(service_instance.steps.last.result)
+        end
+
+        it "copies result of last step" do
+          expect(method_value.object_id).not_to eq(service_instance.steps.last.result.object_id)
         end
       end
     end

--- a/spec/lib/convenient_service/service/plugins/has_result_steps/middleware_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_steps/middleware_spec.rb
@@ -195,11 +195,11 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Middleware d
         end
 
         it "returns result of intermediate step" do
-          expect(method_value).to eq(service_instance.steps.select(&:completed?).last.result)
+          expect(method_value).to eq(ConvenientService::Utils::Array.find_last(service_instance.steps, &:completed?).result)
         end
 
         it "copies result of intermediate step" do
-          expect(method_value.object_id).not_to eq(service_instance.steps.select(&:completed?).last.result.object_id)
+          expect(method_value.object_id).not_to eq(ConvenientService::Utils::Array.find_last(service_instance.steps, &:completed?).result.object_id)
         end
 
         it "does NOT evaluate results of following steps" do


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Forbid to access service `data`, `message`, and `code` before checkings its status, when service is used as a step.
- Added `unsafe_data`, `unsafe_message`, and `unsafe_code` since they are needed for comparison by `#==`.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Service status should be always checked even for steps. 

## What was the reason?

- It was caused by the following line in `HasResultSteps` middleware: 
  ```ruby
  @last_step ||= entity.steps.find(&:not_success?) || entity.steps.last
  ```

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- Now, the last step always returns a copy. All copies have their own internal state.
   ```ruby
   last_step.result.copy
   ```
## How to test?

- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.

## Before

<img width="720" alt="Screenshot 2022-12-13 at 21 50 20" src="https://user-images.githubusercontent.com/22632866/207430487-6f229999-1346-4d5c-9f81-62c3062339df.png">

<img width="720" alt="Screenshot 2022-12-13 at 21 51 09" src="https://user-images.githubusercontent.com/22632866/207430536-ac2a5986-c54c-49d1-ae10-8ceb883120fa.png">

<img width="1392" alt="Screenshot 2022-12-13 at 21 51 41" src="https://user-images.githubusercontent.com/22632866/207430663-772deb78-063e-41fc-8862-428d0326c525.png">

## After

<img width="720" alt="Screenshot 2022-12-13 at 21 52 40" src="https://user-images.githubusercontent.com/22632866/207430805-2e8a46eb-c800-4c09-a4a9-a2244b3fdda7.png">

<img width="720" alt="Screenshot 2022-12-13 at 21 53 01" src="https://user-images.githubusercontent.com/22632866/207430852-08f745be-090a-46ac-8f3a-5a3b37a835db.png">

<img width="720" alt="Screenshot 2022-12-13 at 21 53 21" src="https://user-images.githubusercontent.com/22632866/207430916-b2b0dd0c-342c-4e12-a4bb-a5c66966d232.png">

