### PR TITLE
CS-22: Fix skipped validations for services with steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,14 @@ jobs:
         run: task rspec:standard
       - name: Install dependencies for appraisals
         run: task deps:install
-      - name: Run RSpec with Rails 5.2
-        run: task rspec:rails_5.2
-      - name: Run RSpec with Rails 6.0
-        run: task rspec:rails_6.0
-      - name: Run RSpec with Rails 6.1
-        run: task rspec:rails_6.1
       - name: Run RSpec with Rails 7.0
         run: task rspec:rails_7.0
+      - name: Run RSpec with Rails 6.1
+        run: task rspec:rails_6.1
+      - name: Run RSpec with Rails 6.0
+        run: task rspec:rails_6.0
+      - name: Run RSpec with Rails 5.2
+        run: task rspec:rails_5.2
       - name: Run RSpec with Dry
         run: task rspec:dry
       ##

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,10 +201,10 @@ tasks:
   rspec:
     cmds:
       - task: rspec:standard
-      - task: rspec:rails_5.2
-      - task: rspec:rails_6.0
-      - task: rspec:rails_6.1
       - task: rspec:rails_7.0
+      - task: rspec:rails_6.1
+      - task: rspec:rails_6.0
+      - task: rspec:rails_5.2
       - task: rspec:dry
 
   ##

--- a/env.rb
+++ b/env.rb
@@ -12,8 +12,12 @@
 #
 ENV["APPRAISAL_NAME"] ||= ENV["BUNDLE_GEMFILE"].to_s.then(&File.method(:basename)).then { |name| name.end_with?(".gemfile") ? name.delete_suffix(".gemfile") : "" }
 
+puts "ENV[\"APPRAISAL_NAME\"] -> `#{ENV["APPRAISAL_NAME"]}`"
+
 ##
 # NOTE: Ruby version may be set by docker.
 # https://github.com/docker-library/ruby/blob/master/3.1/alpine3.16/Dockerfile#L30
 #
 ENV["RUBY_VERSION"] ||= ::RUBY_VERSION
+
+puts "ENV[\"RUBY_VERSION\"] -> `#{ENV["RUBY_VERSION"]}`"

--- a/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
+++ b/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
@@ -31,7 +31,9 @@ module ConvenientService
                 end
 
                 middlewares :result do
-                  use Plugins::Service::HasResultParamsValidations::UsingDryValidation::Middleware
+                  insert_before \
+                    Plugins::Service::HasResultSteps::Middleware,
+                    Plugins::Service::HasResultParamsValidations::UsingDryValidation::Middleware
                 end
               end
             end

--- a/lib/convenient_service/examples/dry/gemfile/services/assert_file_exists.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/assert_file_exists.rb
@@ -12,7 +12,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:path).value(:string)
+                required(:path).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/assert_file_not_empty.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/assert_file_not_empty.rb
@@ -12,7 +12,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:path).value(:string)
+                required(:path).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/assert_npm_package_available.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/assert_npm_package_available.rb
@@ -17,7 +17,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:name).value(:string)
+                required(:name).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/parse_content.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/parse_content.rb
@@ -44,7 +44,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:content).value(:string)
+                required(:content).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/print_shell_command.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/print_shell_command.rb
@@ -18,7 +18,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:text).value(:string)
+                required(:text).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/read_file_content.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/read_file_content.rb
@@ -12,7 +12,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:path).value(:string)
+                required(:path).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/dry/gemfile/services/run_shell.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/run_shell.rb
@@ -13,7 +13,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:command).value(:string)
+                required(:command).filled(:string)
                 optional(:debug).value(:bool)
               end
             end

--- a/lib/convenient_service/examples/dry/gemfile/services/strip_comments.rb
+++ b/lib/convenient_service/examples/dry/gemfile/services/strip_comments.rb
@@ -17,7 +17,7 @@ module ConvenientService
 
             contract do
               schema do
-                required(:content).value(:string)
+                required(:content).filled(:string)
               end
             end
 

--- a/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
+++ b/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
@@ -42,7 +42,9 @@ module ConvenientService
                 end
 
                 middlewares :result do
-                  use Plugins::Service::HasResultParamsValidations::UsingActiveModelValidations::Middleware
+                  insert_before \
+                    Plugins::Service::HasResultSteps::Middleware,
+                    Plugins::Service::HasResultParamsValidations::UsingActiveModelValidations::Middleware
                 end
               end
             end

--- a/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
@@ -34,7 +34,6 @@ module ConvenientService
 
             def resolve_errors
               return {} unless contract.schema
-              return {} unless constructor_kwargs.any?
 
               contract.new
                 .call(constructor_kwargs)

--- a/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
+++ b/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware.rb
@@ -21,15 +21,26 @@ module ConvenientService
             # TODO: Return one or all errors?
             #
             def errors
-              @errors ||=
-                entity
-                  .class
-                  .contract
-                  .new
-                  .call(**entity.constructor_params.kwargs)
-                  .errors
-                  .to_h
-                  .transform_values(&:first)
+              @errors ||= resolve_errors
+            end
+
+            def constructor_kwargs
+              @constructor_kwargs ||= entity.constructor_params.kwargs
+            end
+
+            def contract
+              @contract ||= entity.class.contract
+            end
+
+            def resolve_errors
+              return {} unless contract.schema
+              return {} unless constructor_kwargs.any?
+
+              contract.new
+                .call(constructor_kwargs)
+                .errors
+                .to_h
+                .transform_values(&:first)
             end
           end
         end

--- a/spec/lib/convenient_service/examples/dry/gemfile/dry_service/config_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/dry_service/config_spec.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+return unless defined? ConvenientService::Examples::Dry
+
+# rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+RSpec.describe ConvenientService::Examples::Dry::Gemfile::DryService::Config do
+  example_group "modules" do
+    include ConvenientService::RSpec::Matchers::IncludeModule
+
+    subject { described_class }
+
+    context "when included" do
+      let(:service_class) do
+        Class.new.tap do |klass|
+          klass.class_exec(described_class) do |mod|
+            include mod
+          end
+        end
+      end
+
+      specify { expect(service_class).to include_module(ConvenientService::Configs::Standard) }
+
+      example_group "service" do
+        let(:concerns) do
+          [
+            ConvenientService::Common::Plugins::HasInternals::Concern,
+            ConvenientService::Common::Plugins::HasConstructor::Concern,
+            ConvenientService::Plugins::Common::HasConstructorWithoutInitialize::Concern,
+            ConvenientService::Common::Plugins::CachesConstructorParams::Concern,
+            ConvenientService::Common::Plugins::CanBeCopied::Concern,
+            ConvenientService::Service::Plugins::HasResult::Concern,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Concern,
+            ConvenientService::Service::Plugins::HasResultSteps::Concern,
+            ConvenientService::Service::Plugins::CanRecalculateResult::Concern,
+            ConvenientService::Service::Plugins::HasResultStatusCheckShortSyntax::Concern,
+            ConvenientService::Common::Plugins::HasCallbacks::Concern,
+            ConvenientService::Common::Plugins::HasAroundCallbacks::Concern,
+            ConvenientService::Service::Plugins::HasInspect::Concern,
+            ConvenientService::Common::Plugins::AssignsAttributesInConstructor::UsingDryInitializer::Concern,
+            ConvenientService::Service::Plugins::HasResultParamsValidations::UsingDryValidation::Concern
+          ]
+        end
+
+        let(:initialize_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Common::Plugins::CachesConstructorParams::Middleware
+          ]
+        end
+
+        let(:result_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResult::Middleware,
+            ConvenientService::Service::Plugins::HasResultParamsValidations::UsingDryValidation::Middleware,
+            ConvenientService::Service::Plugins::HasResultSteps::Middleware,
+            ConvenientService::Common::Plugins::HasCallbacks::Middleware,
+            ConvenientService::Common::Plugins::HasAroundCallbacks::Middleware,
+            ConvenientService::Service::Plugins::RaisesOnDoubleResult::Middleware,
+            ConvenientService::Common::Plugins::CachesReturnValue::Middleware
+          ]
+        end
+
+        let(:success_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Success::Middleware
+          ]
+        end
+
+        let(:failure_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Failure::Middleware
+          ]
+        end
+
+        let(:error_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Error::Middleware
+          ]
+        end
+
+        let(:step_class_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultMethodSteps::Middleware
+          ]
+        end
+
+        it "sets service concerns" do
+          expect(service_class.concerns.to_a).to eq(concerns)
+        end
+
+        it "sets service middlewares for `initialize`" do
+          expect(service_class.middlewares(:initialize).to_a).to eq(initialize_middlewares)
+        end
+
+        it "sets service middlewares for `result`" do
+          expect(service_class.middlewares(:result).to_a).to eq(result_middlewares)
+        end
+
+        it "sets service middlewares for `success`" do
+          expect(service_class.middlewares(:success).to_a).to eq(success_middlewares)
+        end
+
+        it "sets service middlewares for `failure`" do
+          expect(service_class.middlewares(:failure).to_a).to eq(failure_middlewares)
+        end
+
+        it "sets service middlewares for `error`" do
+          expect(service_class.middlewares(:error).to_a).to eq(error_middlewares)
+        end
+
+        it "sets service middlewares for class `step`" do
+          expect(service_class.middlewares(:step, scope: :class).to_a).to eq(step_class_middlewares)
+        end
+
+        example_group "service internals" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+            ]
+          end
+
+          it "sets service internals concerns" do
+            expect(service_class::Internals.concerns.to_a).to eq(concerns)
+          end
+        end
+
+        example_group "service result" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Concern,
+              ConvenientService::Common::Plugins::HasConstructor::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasResultShortSyntax::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::CanRecalculateResult::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasInspect::Concern
+            ]
+          end
+
+          let(:initialize_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Middleware
+            ]
+          end
+
+          let(:is_success_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_failure_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_error_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_success_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_failure_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_error_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:data_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          let(:message_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          let(:code_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          it "sets service result concerns" do
+            expect(service_class::Result.concerns.to_a).to eq(concerns)
+          end
+
+          it "sets service result middlewares for `initialize`" do
+            expect(service_class::Result.middlewares(:initialize).to_a).to eq(initialize_middlewares)
+          end
+
+          it "sets service result middlewares for `success?`" do
+            expect(service_class::Result.middlewares(:success?).to_a).to eq(is_success_middlewares)
+          end
+
+          it "sets service result middlewares for `failure?`" do
+            expect(service_class::Result.middlewares(:failure?).to_a).to eq(is_failure_middlewares)
+          end
+
+          it "sets service result middlewares for `error?`" do
+            expect(service_class::Result.middlewares(:error?).to_a).to eq(is_error_middlewares)
+          end
+
+          it "sets service result middlewares for `not_success?`" do
+            expect(service_class::Result.middlewares(:not_success?).to_a).to eq(is_not_success_middlewares)
+          end
+
+          it "sets service result middlewares for `not_failure?`" do
+            expect(service_class::Result.middlewares(:not_failure?).to_a).to eq(is_not_failure_middlewares)
+          end
+
+          it "sets service result middlewares for `not_error?`" do
+            expect(service_class::Result.middlewares(:not_error?).to_a).to eq(is_not_error_middlewares)
+          end
+
+          it "sets service result middlewares for `data`" do
+            expect(service_class::Result.middlewares(:data).to_a).to eq(data_middlewares)
+          end
+
+          it "sets service result middlewares for `message`" do
+            expect(service_class::Result.middlewares(:message).to_a).to eq(message_middlewares)
+          end
+
+          it "sets service result middlewares for `code`" do
+            expect(service_class::Result.middlewares(:code).to_a).to eq(code_middlewares)
+          end
+
+          example_group "service result internals" do
+            let(:concerns) do
+              [
+                ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+              ]
+            end
+
+            it "sets service result internals concerns" do
+              expect(service_class::Internals.concerns.to_a).to eq(concerns)
+            end
+          end
+        end
+
+        example_group "service step" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Concern,
+              ConvenientService::Service::Plugins::HasResultSteps::Entities::Step::Plugins::HasInspect::Concern
+            ]
+          end
+
+          let(:result_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Common::Plugins::CachesReturnValue::Middleware
+            ]
+          end
+
+          it "sets service step concerns" do
+            expect(service_class::Step.concerns.to_a).to eq(concerns)
+          end
+
+          it "sets service step middlewares for `result`" do
+            expect(service_class::Step.middlewares(:result).to_a).to eq(result_middlewares)
+          end
+
+          example_group "service step internals" do
+            let(:concerns) do
+              [
+                ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+              ]
+            end
+
+            it "sets service internals concerns" do
+              expect(service_class::Step::Internals.concerns.to_a).to eq(concerns)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/assert_file_exists_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/assert_file_exists_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertFileEx
   describe "#result" do
     subject(:result) { service.result }
 
+    context "when path is NOT present" do
+      let(:path) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(path: "must be filled")
+      end
+    end
+
     context "when file with path does NOT exist" do
       let(:path) { "non_existing_path" }
 
@@ -40,10 +48,7 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertFileEx
       let(:path) { tempfile.path }
 
       it "returns success" do
-        ##
-        # TODO: Matcher.
-        #
-        expect(result).to be_success
+        expect(result).to be_success.without_data
       end
     end
   end

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/assert_file_not_empty_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/assert_file_not_empty_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertFileNo
 
     let(:path) { tempfile.path }
 
+    context "when path is NOT present" do
+      let(:path) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(path: "must be filled")
+      end
+    end
+
     context "when file is NOT empty" do
       ##
       # NOTE: Tempfile uses its own let in order to prevent its premature garbage collection.
@@ -33,10 +41,7 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertFileNo
       let(:tempfile) { Tempfile.new.tap { |file| file.write("content") }.tap(&:close) }
 
       it "returns success" do
-        ##
-        # TODO: Matcher.
-        #
-        expect(result).to be_success
+        expect(result).to be_success.without_data
       end
     end
 

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/assert_npm_package_available_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/assert_npm_package_available_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertNpmPac
   let(:service) { described_class.new(**default_options) }
 
   let(:default_options) { {name: name} }
-  let(:name) { double }
+  let(:name) { "strip-comments" }
 
   example_group "modules" do
     subject { described_class }
@@ -26,44 +26,56 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::AssertNpmPac
   describe "#result" do
     subject(:result) { service.result }
 
-    before do
-      stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable).to return_error
-    end
+    context "when name is NOT valid" do
+      context "when name is NOT present" do
+        let(:name) { "" }
 
-    context "when node is NOT available" do
-      it "returns intermediate error" do
-        expect(result).to be_error.of(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable)
+        it "returns failure with data" do
+          expect(result).to be_failure.with_data(name: "must be filled")
+        end
       end
     end
 
-    context "when node is available" do
-      let(:npm_package_available_command) { "npm list #{name} --depth=0 > /dev/null 2>&1" }
-
+    context "when name is valid" do
       before do
-        stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable).to return_success
+        stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable).to return_error
       end
 
-      context "when npm package is NOT available" do
-        before do
-          stub_service(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
-            .with_arguments(command: npm_package_available_command)
-            .to return_error
-        end
-
+      context "when node is NOT available" do
         it "returns intermediate error" do
-          expect(result).to be_error.of(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+          expect(result).to be_error.of(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable)
         end
       end
 
-      context "when npm package is available" do
+      context "when node is available" do
+        let(:npm_package_available_command) { "npm list #{name} --depth=0 > /dev/null 2>&1" }
+
         before do
-          stub_service(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
-            .with_arguments(command: npm_package_available_command)
-            .to return_success
+          stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertNodeAvailable).to return_success
         end
 
-        it "returns success" do
-          expect(result).to be_success.of(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+        context "when npm package is NOT available" do
+          before do
+            stub_service(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+              .with_arguments(command: npm_package_available_command)
+              .to return_error
+          end
+
+          it "returns intermediate error" do
+            expect(result).to be_error.of(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+          end
+        end
+
+        context "when npm package is available" do
+          before do
+            stub_service(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+              .with_arguments(command: npm_package_available_command)
+              .to return_success
+          end
+
+          it "returns success" do
+            expect(result).to be_success.of(ConvenientService::Examples::Dry::Gemfile::Services::RunShell)
+          end
         end
       end
     end

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/parse_content_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/parse_content_spec.rb
@@ -151,6 +151,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::ParseContent
       end
     end
 
+    context "when content is NOT present" do
+      let(:content) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(content: "must be filled")
+      end
+    end
+
     context "when content has invalid Ruby syntax" do
       before do
         stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertValidRubySyntax)

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/print_shell_command_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/print_shell_command_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::PrintShellCo
 
     let(:out_content) { out.tap(&:rewind).read }
 
+    context "when text is NOT present" do
+      let(:text) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(text: "must be filled")
+      end
+    end
+
     it "prints text" do
       result
 

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/read_file_content_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/read_file_content_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::ReadFileCont
   let(:service) { described_class.new(**default_options) }
 
   let(:default_options) { {path: path} }
-  let(:path) { double }
+  let(:path) { "Gemfile" }
 
   example_group "modules" do
     subject { described_class }
@@ -25,6 +25,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::ReadFileCont
 
   describe "#result" do
     subject(:result) { service.result }
+
+    context "when path is NOT present" do
+      let(:path) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(path: "must be filled")
+      end
+    end
 
     context "when file does NOT exist" do
       before do

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/run_shell_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/run_shell_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::RunShell do
   describe "#result" do
     subject(:result) { service.result }
 
+    context "when command is NOT present" do
+      let(:command) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(command: "must be filled")
+      end
+    end
+
     context "when shell command has non-zero code" do
       before do
         ##

--- a/spec/lib/convenient_service/examples/dry/gemfile/services/strip_comments_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/services/strip_comments_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::Services::StripComment
       RUBY
     end
 
+    context "when content is NOT present" do
+      let(:content) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(content: "must be filled")
+      end
+    end
+
     context "when `strip-comments` npm package is not available" do
       before do
         stub_service(ConvenientService::Examples::Dry::Gemfile::Services::AssertNpmPackageAvailable)

--- a/spec/lib/convenient_service/examples/rails/gemfile/rails_service/config_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/rails_service/config_spec.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+return unless defined? ConvenientService::Examples::Rails
+
+# rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+RSpec.describe ConvenientService::Examples::Rails::Gemfile::RailsService::Config do
+  example_group "modules" do
+    include ConvenientService::RSpec::Matchers::IncludeModule
+
+    subject { described_class }
+
+    context "when included" do
+      let(:service_class) do
+        Class.new.tap do |klass|
+          klass.class_exec(described_class) do |mod|
+            include mod
+          end
+        end
+      end
+
+      specify { expect(service_class).to include_module(ConvenientService::Configs::Standard) }
+
+      example_group "service" do
+        let(:concerns) do
+          [
+            ConvenientService::Common::Plugins::HasInternals::Concern,
+            ConvenientService::Common::Plugins::HasConstructor::Concern,
+            ConvenientService::Plugins::Common::HasConstructorWithoutInitialize::Concern,
+            ConvenientService::Common::Plugins::CachesConstructorParams::Concern,
+            ConvenientService::Common::Plugins::CanBeCopied::Concern,
+            ConvenientService::Service::Plugins::HasResult::Concern,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Concern,
+            ConvenientService::Service::Plugins::HasResultSteps::Concern,
+            ConvenientService::Service::Plugins::CanRecalculateResult::Concern,
+            ConvenientService::Service::Plugins::HasResultStatusCheckShortSyntax::Concern,
+            ConvenientService::Common::Plugins::HasCallbacks::Concern,
+            ConvenientService::Common::Plugins::HasAroundCallbacks::Concern,
+            ConvenientService::Service::Plugins::HasInspect::Concern,
+            ConvenientService::Common::Plugins::AssignsAttributesInConstructor::UsingActiveModelAttributeAssignment::Concern,
+            ConvenientService::Common::Plugins::HasAttributes::UsingActiveModelAttributes::Concern,
+            ConvenientService::Service::Plugins::HasResultParamsValidations::UsingActiveModelValidations::Concern
+          ]
+        end
+
+        let(:initialize_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Common::Plugins::CachesConstructorParams::Middleware,
+            ConvenientService::Common::Plugins::AssignsAttributesInConstructor::UsingActiveModelAttributeAssignment::Middleware
+          ]
+        end
+
+        let(:result_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResult::Middleware,
+            ConvenientService::Service::Plugins::HasResultParamsValidations::UsingActiveModelValidations::Middleware,
+            ConvenientService::Service::Plugins::HasResultSteps::Middleware,
+            ConvenientService::Common::Plugins::HasCallbacks::Middleware,
+            ConvenientService::Common::Plugins::HasAroundCallbacks::Middleware,
+            ConvenientService::Service::Plugins::RaisesOnDoubleResult::Middleware,
+            ConvenientService::Common::Plugins::CachesReturnValue::Middleware
+          ]
+        end
+
+        let(:success_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Success::Middleware
+          ]
+        end
+
+        let(:failure_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Failure::Middleware
+          ]
+        end
+
+        let(:error_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultShortSyntax::Error::Middleware
+          ]
+        end
+
+        let(:step_class_middlewares) do
+          [
+            ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+            ConvenientService::Service::Plugins::HasResultMethodSteps::Middleware
+          ]
+        end
+
+        it "sets service concerns" do
+          expect(service_class.concerns.to_a).to eq(concerns)
+        end
+
+        it "sets service middlewares for `initialize`" do
+          expect(service_class.middlewares(:initialize).to_a).to eq(initialize_middlewares)
+        end
+
+        it "sets service middlewares for `result`" do
+          expect(service_class.middlewares(:result).to_a).to eq(result_middlewares)
+        end
+
+        it "sets service middlewares for `success`" do
+          expect(service_class.middlewares(:success).to_a).to eq(success_middlewares)
+        end
+
+        it "sets service middlewares for `failure`" do
+          expect(service_class.middlewares(:failure).to_a).to eq(failure_middlewares)
+        end
+
+        it "sets service middlewares for `error`" do
+          expect(service_class.middlewares(:error).to_a).to eq(error_middlewares)
+        end
+
+        it "sets service middlewares for class `step`" do
+          expect(service_class.middlewares(:step, scope: :class).to_a).to eq(step_class_middlewares)
+        end
+
+        example_group "service internals" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+            ]
+          end
+
+          it "sets service internals concerns" do
+            expect(service_class::Internals.concerns.to_a).to eq(concerns)
+          end
+        end
+
+        example_group "service result" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Concern,
+              ConvenientService::Common::Plugins::HasConstructor::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasResultShortSyntax::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::CanRecalculateResult::Concern,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasInspect::Concern
+            ]
+          end
+
+          let(:initialize_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Middleware
+            ]
+          end
+
+          let(:is_success_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_failure_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_error_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_success_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_failure_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:is_not_error_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::MarksResultStatusAsChecked::Middleware
+            ]
+          end
+
+          let(:data_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          let(:message_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          let(:code_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::RaisesOnNotCheckedResultStatus::Middleware
+            ]
+          end
+
+          it "sets service result concerns" do
+            expect(service_class::Result.concerns.to_a).to eq(concerns)
+          end
+
+          it "sets service result middlewares for `initialize`" do
+            expect(service_class::Result.middlewares(:initialize).to_a).to eq(initialize_middlewares)
+          end
+
+          it "sets service result middlewares for `success?`" do
+            expect(service_class::Result.middlewares(:success?).to_a).to eq(is_success_middlewares)
+          end
+
+          it "sets service result middlewares for `failure?`" do
+            expect(service_class::Result.middlewares(:failure?).to_a).to eq(is_failure_middlewares)
+          end
+
+          it "sets service result middlewares for `error?`" do
+            expect(service_class::Result.middlewares(:error?).to_a).to eq(is_error_middlewares)
+          end
+
+          it "sets service result middlewares for `not_success?`" do
+            expect(service_class::Result.middlewares(:not_success?).to_a).to eq(is_not_success_middlewares)
+          end
+
+          it "sets service result middlewares for `not_failure?`" do
+            expect(service_class::Result.middlewares(:not_failure?).to_a).to eq(is_not_failure_middlewares)
+          end
+
+          it "sets service result middlewares for `not_error?`" do
+            expect(service_class::Result.middlewares(:not_error?).to_a).to eq(is_not_error_middlewares)
+          end
+
+          it "sets service result middlewares for `data`" do
+            expect(service_class::Result.middlewares(:data).to_a).to eq(data_middlewares)
+          end
+
+          it "sets service result middlewares for `message`" do
+            expect(service_class::Result.middlewares(:message).to_a).to eq(message_middlewares)
+          end
+
+          it "sets service result middlewares for `code`" do
+            expect(service_class::Result.middlewares(:code).to_a).to eq(code_middlewares)
+          end
+
+          example_group "service result internals" do
+            let(:concerns) do
+              [
+                ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+              ]
+            end
+
+            it "sets service result internals concerns" do
+              expect(service_class::Internals.concerns.to_a).to eq(concerns)
+            end
+          end
+        end
+
+        example_group "service step" do
+          let(:concerns) do
+            [
+              ConvenientService::Common::Plugins::HasInternals::Concern,
+              ConvenientService::Service::Plugins::HasResultSteps::Entities::Step::Plugins::HasInspect::Concern
+            ]
+          end
+
+          let(:result_middlewares) do
+            [
+              ConvenientService::Common::Plugins::NormalizesEnv::Middleware,
+              ConvenientService::Common::Plugins::CachesReturnValue::Middleware
+            ]
+          end
+
+          it "sets service step concerns" do
+            expect(service_class::Step.concerns.to_a).to eq(concerns)
+          end
+
+          it "sets service step middlewares for `result`" do
+            expect(service_class::Step.middlewares(:result).to_a).to eq(result_middlewares)
+          end
+
+          example_group "service step internals" do
+            let(:concerns) do
+              [
+                ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+              ]
+            end
+
+            it "sets service internals concerns" do
+              expect(service_class::Step::Internals.concerns.to_a).to eq(concerns)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
   describe "#result" do
     subject(:result) { service.result }
 
-    context "when file is NOT present?" do
+    context "when path is NOT present?" do
       let(:path) { "" }
 
-      it "returns error with message" do
+      it "returns failure with data" do
         expect(result).to be_failure.with_data(path: "can't be blank")
       end
     end
@@ -72,10 +72,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
       let(:path) { tempfile.path }
 
       it "returns success" do
-        ##
-        # TODO: Matcher.
-        #
-        expect(result).to be_success
+        expect(result).to be_success.without_data
       end
     end
   end

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
   describe "#result" do
     subject(:result) { service.result }
 
+    context "when file is NOT present?" do
+      let(:path) { "" }
+
+      it "returns error with message" do
+        expect(result).to be_failure.with_data(path: "can't be blank")
+      end
+    end
+
     context "when file with path does NOT exist" do
       let(:path) { "non_existing_path" }
 

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_exists_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
   describe "#result" do
     subject(:result) { service.result }
 
-    context "when path is NOT present?" do
+    context "when path is NOT present" do
       let(:path) { "" }
 
       it "returns failure with data" do

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
 
     let(:path) { tempfile.path }
 
+    context "when path is NOT present?" do
+      let(:path) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(path: "can't be blank")
+      end
+    end
+
     context "when file is NOT empty" do
       ##
       # NOTE: Tempfile uses its own let in order to prevent its premature garbage collection.

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
 
     let(:path) { tempfile.path }
 
-    context "when path is NOT present?" do
+    context "when path is NOT present" do
       let(:path) { "" }
 
       it "returns failure with data" do

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_file_not_empty_spec.rb
@@ -65,10 +65,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertFile
       let(:tempfile) { Tempfile.new.tap { |file| file.write("content") }.tap(&:close) }
 
       it "returns success" do
-        ##
-        # TODO: Matcher.
-        #
-        expect(result).to be_success
+        expect(result).to be_success.without_data
       end
     end
 

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertNpmP
   let(:service) { described_class.new(**default_options) }
 
   let(:default_options) { {name: name} }
-  let(:name) { double }
+  let(:name) { "strip-comments" }
 
   example_group "modules" do
     subject { described_class }

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertNpmP
     subject(:result) { service.result }
 
     context "when name is NOT valid" do
-      context "when name is NOT present?" do
+      context "when name is NOT present" do
         let(:name) { "" }
 
         it "returns failure with data" do

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/assert_npm_package_available_spec.rb
@@ -42,44 +42,56 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::AssertNpmP
   describe "#result" do
     subject(:result) { service.result }
 
-    before do
-      stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable).to return_error
-    end
+    context "when name is NOT valid" do
+      context "when name is NOT present?" do
+        let(:name) { "" }
 
-    context "when node is NOT available" do
-      it "returns intermediate error" do
-        expect(result).to be_error.of(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable)
+        it "returns failure with data" do
+          expect(result).to be_failure.with_data(name: "can't be blank")
+        end
       end
     end
 
-    context "when node is available" do
-      let(:npm_package_available_command) { "npm list #{name} --depth=0 > /dev/null 2>&1" }
-
+    context "when name is valid" do
       before do
-        stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable).to return_success
+        stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable).to return_error
       end
 
-      context "when npm package is NOT available" do
-        before do
-          stub_service(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
-            .with_arguments(command: npm_package_available_command)
-            .to return_error
-        end
-
+      context "when node is NOT available" do
         it "returns intermediate error" do
-          expect(result).to be_error.of(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+          expect(result).to be_error.of(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable)
         end
       end
 
-      context "when npm package is available" do
+      context "when node is available" do
+        let(:npm_package_available_command) { "npm list #{name} --depth=0 > /dev/null 2>&1" }
+
         before do
-          stub_service(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
-            .with_arguments(command: npm_package_available_command)
-            .to return_success
+          stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertNodeAvailable).to return_success
         end
 
-        it "returns success" do
-          expect(result).to be_success.of(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+        context "when npm package is NOT available" do
+          before do
+            stub_service(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+              .with_arguments(command: npm_package_available_command)
+              .to return_error
+          end
+
+          it "returns intermediate error" do
+            expect(result).to be_error.of(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+          end
+        end
+
+        context "when npm package is available" do
+          before do
+            stub_service(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+              .with_arguments(command: npm_package_available_command)
+              .to return_success
+          end
+
+          it "returns success" do
+            expect(result).to be_success.of(ConvenientService::Examples::Rails::Gemfile::Services::RunShell)
+          end
         end
       end
     end

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/parse_content_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/parse_content_spec.rb
@@ -171,6 +171,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::ParseConte
       end
     end
 
+    context "when content is NOT present" do
+      let(:content) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(content: "can't be blank")
+      end
+    end
+
     context "when content has invalid Ruby syntax" do
       before do
         stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertValidRubySyntax)

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/print_shell_command_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/print_shell_command_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::PrintShell
 
     let(:out_content) { out.tap(&:rewind).read }
 
+    context "when text is NOT present" do
+      let(:text) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(text: "can't be blank")
+      end
+    end
+
     it "prints text" do
       result
 

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/read_file_content_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/read_file_content_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::ReadFileCo
   describe "#result" do
     subject(:result) { service.result }
 
+    context "when path is NOT present" do
+      let(:path) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(path: "can't be blank")
+      end
+    end
+
     context "when file does NOT exist" do
       before do
         stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertFileExists)

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/run_shell_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/run_shell_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::RunShell d
   describe "#result" do
     subject(:result) { service.result }
 
+    context "when command is NOT present" do
+      let(:command) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(command: "can't be blank")
+      end
+    end
+
     context "when shell command has non-zero code" do
       before do
         ##

--- a/spec/lib/convenient_service/examples/rails/gemfile/services/strip_comments_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/services/strip_comments_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::Services::StripComme
       RUBY
     end
 
+    context "when content is NOT present" do
+      let(:content) { "" }
+
+      it "returns failure with data" do
+        expect(result).to be_failure.with_data(content: "can't be blank")
+      end
+    end
+
     context "when `strip-comments` npm package is not available" do
       before do
         stub_service(ConvenientService::Examples::Rails::Gemfile::Services::AssertNpmPackageAvailable)

--- a/spec/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_params_validations/using_dry_validation/middleware_spec.rb
@@ -78,16 +78,74 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultParamsValidations::
 
       let(:service_instance) { service_class.new }
 
+      context "when contact does NOT have schema" do
+        ##
+        # TODO: Factories. Highest priority.
+        #
+        # rubocop:disable RSpec/LeakyConstantDeclaration, Lint/ConstantDefinitionInBlock
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Common::Plugins::HasInternals::Concern
+            include ConvenientService::Common::Plugins::CachesConstructorParams::Concern
+            include ConvenientService::Service::Plugins::HasResult::Concern
+            include ConvenientService::Service::Plugins::HasResultParamsValidations::UsingDryValidation::Concern
+
+            class self::Result
+              include ConvenientService::Core
+
+              concerns do
+                use ConvenientService::Common::Plugins::HasInternals::Concern
+                use ConvenientService::Common::Plugins::HasConstructor::Concern
+                use ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Concern
+              end
+
+              middlewares :initialize do
+                use ConvenientService::Common::Plugins::NormalizesEnv::Middleware
+
+                use ConvenientService::Service::Plugins::HasResult::Entities::Result::Plugins::HasJsendStatusAndAttributes::Middleware
+              end
+
+              class self::Internals
+                include ConvenientService::Core
+
+                concerns do
+                  use ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+                end
+              end
+            end
+
+            class self::Internals
+              include ConvenientService::Common::Plugins::HasInternals::Entities::Internals::Plugins::HasCache::Concern
+            end
+
+            def result
+              success
+            end
+          end
+        end
+        # rubocop:enable RSpec/LeakyConstantDeclaration, Lint/ConstantDefinitionInBlock
+
+        before do
+          service_instance.internals.cache.write(:constructor_params, ConvenientService::Common::Plugins::CachesConstructorParams::Entities::ConstructorParams.new(kwargs: {foo: "x"}))
+        end
+
+        specify do
+          expect { method_value }
+            .to call_chain_next.on(method)
+            .and_return_its_value
+        end
+      end
+
       context "when validation does NOT have any errors" do
         before do
           service_instance.internals.cache.write(:constructor_params, ConvenientService::Common::Plugins::CachesConstructorParams::Entities::ConstructorParams.new(kwargs: {foo: "x"}))
         end
 
-        specify {
+        specify do
           expect { method_value }
             .to call_chain_next.on(method)
             .and_return_its_value
-        }
+        end
       end
 
       context "when validation has any error" do


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Placed `HasResultParamsValidations::UsingActiveModelValidations` and `HasResultParamsValidations::UsingDryValidation` before `HasResultSteps` in `Rails` and `Dry` configs.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Since validations were NOT called for services with steps. 

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- Using [insert_before](https://github.com/Ibsciss/ruby-middleware#manipulating-a-stack).

## How to test?

- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [ ] I have performed a self-review of my code.
- [ ] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [ ] CI is green.
