### PR TITLE
CS-24: Fix `can_have_stubbed_result` when it's called in NON-TEST environment

### DIFF
--- a/lib/convenient_service/service/plugins/can_have_stubbed_result/concern.rb
+++ b/lib/convenient_service/service/plugins/can_have_stubbed_result/concern.rb
@@ -20,7 +20,7 @@ module ConvenientService
             #   TODO: Mutex for thread-safety when parallel steps will be supported.
             #
             def stubbed_results
-              return unless ::RSpec.current_example
+              return Support::Cache.new unless Support::Gems::RSpec.current_example
 
               cache = Utils::Object.instance_variable_fetch(::RSpec.current_example, :@__convenient_service_stubbed_results__) { Support::Cache.new }
 

--- a/lib/convenient_service/service/plugins/can_have_stubbed_result/concern.rb
+++ b/lib/convenient_service/service/plugins/can_have_stubbed_result/concern.rb
@@ -20,6 +20,8 @@ module ConvenientService
             #   TODO: Mutex for thread-safety when parallel steps will be supported.
             #
             def stubbed_results
+              return unless ::RSpec.current_example
+
               cache = Utils::Object.instance_variable_fetch(::RSpec.current_example, :@__convenient_service_stubbed_results__) { Support::Cache.new }
 
               cache.scope(self)

--- a/lib/convenient_service/service/plugins/can_have_stubbed_result/middleware.rb
+++ b/lib/convenient_service/service/plugins/can_have_stubbed_result/middleware.rb
@@ -12,8 +12,6 @@ module ConvenientService
           # @return [Object] Can be any type.
           #
           def next(*args, **kwargs, &block)
-            return chain.next(*args, **kwargs, &block) unless cache
-
             key_with_arguments = cache.keygen(*args, **kwargs, &block)
             key_without_arguments = cache.keygen
 

--- a/lib/convenient_service/service/plugins/can_have_stubbed_result/middleware.rb
+++ b/lib/convenient_service/service/plugins/can_have_stubbed_result/middleware.rb
@@ -12,6 +12,8 @@ module ConvenientService
           # @return [Object] Can be any type.
           #
           def next(*args, **kwargs, &block)
+            return chain.next(*args, **kwargs, &block) unless cache
+
             key_with_arguments = cache.keygen(*args, **kwargs, &block)
             key_without_arguments = cache.keygen
 

--- a/lib/convenient_service/support/gems/rspec.rb
+++ b/lib/convenient_service/support/gems/rspec.rb
@@ -29,6 +29,21 @@ module ConvenientService
           def version
             loaded? ? Support::Version.new(::RSpec::Core::Version::STRING) : Support::Version.null_version
           end
+
+          ##
+          # @return [RSpec::Core::Example, nil]
+          #
+          # @internal
+          #   NOTE: Returns `nil` in a non-test environment
+          #
+          #   `::RSpec.current_example` docs:
+          #   - https://www.rubydoc.info/github/rspec/rspec-core/RSpec.current_example
+          #   - https://github.com/rspec/rspec-core/blob/v3.12.0/lib/rspec/core.rb#L122
+          #   - https://relishapp.com/rspec/rspec-core/docs/metadata/current-example
+          #
+          def current_example
+            ::RSpec.current_example
+          end
         end
       end
     end

--- a/lib/convenient_service/support/gems/rspec.rb
+++ b/lib/convenient_service/support/gems/rspec.rb
@@ -42,7 +42,7 @@ module ConvenientService
           #   - https://relishapp.com/rspec/rspec-core/docs/metadata/current-example
           #
           def current_example
-            ::RSpec.current_example
+            ::RSpec.current_example if loaded?
           end
         end
       end

--- a/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
@@ -32,11 +32,23 @@ RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concer
 
   example_group "class methods" do
     describe ".stubbed_results" do
-      it "returns cache scoped by self" do
-        expect(service_class.stubbed_results).to eq(ConvenientService::Support::Cache.new.scope(service_class))
+      context "when `Rspec.current_example` is nil" do
+        before do
+          allow(ConvenientService::Support::Gems::RSpec).to receive(:current_example).and_return(nil)
+        end
+
+        it "returns empty cache" do
+          expect(service_class.stubbed_results).to eq(ConvenientService::Support::Cache.new)
+        end
       end
 
-      specify { expect { service_class.stubbed_results }.to cache_its_value }
+      context "when `Rspec.current_example` is present" do
+        it "returns cache scoped by self" do
+          expect(service_class.stubbed_results).to eq(ConvenientService::Support::Cache.new.scope(service_class))
+        end
+
+        specify { expect { service_class.stubbed_results }.to cache_its_value }
+      end
     end
   end
 end

--- a/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 
 require "convenient_service"
+
 # rubocop:disable RSpec/NestedGroups
 RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concern do
   include ConvenientService::RSpec::Matchers::CacheItsValue

--- a/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concer
 
   example_group "class methods" do
     describe ".stubbed_results" do
-      context "when `Rspec.current_example` is nil" do
+      context "when RSpec current example is NOT set" do
         before do
           allow(ConvenientService::Support::Gems::RSpec).to receive(:current_example).and_return(nil)
         end
@@ -43,7 +43,7 @@ RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concer
         end
       end
 
-      context "when `Rspec.current_example` is present" do
+      context "when RSpec is loaded and current example is set" do
         it "returns cache scoped by self" do
           expect(service_class.stubbed_results).to eq(ConvenientService::Support::Cache.new.scope(service_class))
         end

--- a/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 require "convenient_service"
-
+# rubocop:disable RSpec/NestedGroups
 RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concern do
   include ConvenientService::RSpec::Matchers::CacheItsValue
 
@@ -52,3 +52,4 @@ RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concer
     end
   end
 end
+# rubocop:enable RSpec/NestedGroups

--- a/spec/lib/convenient_service/support/gems/rspec_spec.rb
+++ b/spec/lib/convenient_service/support/gems/rspec_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe ConvenientService::Support::Gems::RSpec do
         end
       end
     end
+
+    describe "current_example" do
+      it "returns current_example" do |example|
+        expect(described_class.current_example).to eq(example)
+      end
+
+      context "when `RSpec` is NOT loaded" do
+        before do
+          allow(described_class).to receive(:loaded?).and_return(false)
+        end
+
+        it "returns nil" do
+          expect(described_class.current_example).to be_nil
+        end
+      end
+    end
   end
 end
 # rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->
- Fixed `can_have_stubbed_result` plugin

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- There is an error when the service is called in the development environment(version 0.3.0), because `::RSpec.current_example` does NOT exist in any environments besides TEST

## How to test?

- `task rspec -- spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Notes
<!--- Additional info, links, screenshots, actually anything that helps to recreate the way of thoughts (optional). -->
<img width="1762" alt="Screenshot 2022-12-19 at 02 30 24" src="https://user-images.githubusercontent.com/67630290/208327691-8bf7eaee-1776-4efd-b881-183bd30cbe27.png">

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
