### PR TITLE
CS-25: A better message for typo in step out methods

### DIFF
--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data.rb
@@ -22,6 +22,10 @@ module ConvenientService
                       @value = value
                     end
 
+                    def has_key?(key)
+                      value.has_key?(key.to_sym)
+                    end
+
                     def ==(other)
                       casted = cast(other)
 

--- a/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data.rb
+++ b/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data.rb
@@ -22,7 +22,11 @@ module ConvenientService
                       @value = value
                     end
 
-                    def has_key?(key)
+                    ##
+                    # @param key [String, Symbol]
+                    # @return [Boolean]
+                    #
+                    def has_attribute?(key)
                       value.has_key?(key.to_sym)
                     end
 

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container.rb
@@ -26,11 +26,13 @@ module ConvenientService
                   #
                   <<~RUBY.tap { |code| container.klass.class_eval(code, __FILE__, __LINE__ + 1) }
                     def #{name}
-                      step, key, name, error = steps[#{index}], :#{key}, :#{name}, #{error}
+                      step, key, method_name = steps[#{index}], :#{key}, :#{name}
 
-                      return step.result.data[key] if step.completed?
+                      raise #{not_completed_step_error}.new(step: step, method_name: method_name) unless step.completed?
 
-                      raise ::#{error}.new(step: step, method_name: name)
+                      raise #{not_existing_step_result_data_attribute_error}.new(step: step, key: key) unless step.result.data.has_key?(key)
+
+                      step.result.data[key]
                     end
                   RUBY
 
@@ -39,11 +41,16 @@ module ConvenientService
 
                 private
 
-                def error
-                  @error ||=
-                    <<~RUBY.chomp
-                      ConvenientService::Service::Plugins::HasResultSteps::Entities::Method::Errors::NotCompletedStep
-                    RUBY
+                def not_completed_step_error
+                  <<~RUBY.chomp
+                    ::ConvenientService::Service::Plugins::HasResultSteps::Entities::Method::Errors::NotCompletedStep
+                  RUBY
+                end
+
+                def not_existing_step_result_data_attribute_error
+                  <<~RUBY.chomp
+                    ::ConvenientService::Service::Plugins::HasResultSteps::Entities::Method::Errors::NotExistingStepResultDataAttribute
+                  RUBY
                 end
               end
             end

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container.rb
@@ -30,7 +30,7 @@ module ConvenientService
 
                       raise #{not_completed_step_error}.new(step: step, method_name: method_name) unless step.completed?
 
-                      raise #{not_existing_step_result_data_attribute_error}.new(step: step, key: key) unless step.result.data.has_key?(key)
+                      raise #{not_existing_step_result_data_attribute_error}.new(step: step, key: key) unless step.result.data.has_attribute?(key)
 
                       step.result.data[key]
                     end

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
@@ -118,6 +118,20 @@ module ConvenientService
                   super(message)
                 end
               end
+
+              class NotExistingStepResultDataAttribute < ConvenientService::Error
+                def initialize(key:, step:)
+                  message = <<~TEXT
+                    Step `#{step.service}` result does NOT return `#{key}` data attribute.
+
+                    Maybe there is a typo in `out` definition?
+
+                    Or `success` of `#{step.service}` accepts a wrong key?
+                  TEXT
+
+                  super(message)
+                end
+              end
             end
           end
         end

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
@@ -120,6 +120,10 @@ module ConvenientService
               end
 
               class NotExistingStepResultDataAttribute < ConvenientService::Error
+                ##
+                # @internal
+                #   TODO: `step.printable_service`.
+                #
                 def initialize(key:, step:)
                   message = <<~TEXT
                     Step `#{step.service}` result does NOT return `#{key}` data attribute.

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/method/errors.rb
@@ -110,7 +110,7 @@ module ConvenientService
               class NotCompletedStep < ConvenientService::Error
                 def initialize(method_name:, step:)
                   message = <<~TEXT
-                    `out` method `#{method_name}` is called before its corresponding step `#{step.service}` is completed.
+                    `out` method `#{method_name}` is called before its corresponding step `#{step.printable_service}` is completed.
 
                     Maybe it makes sense to change the steps order?
                   TEXT
@@ -120,17 +120,13 @@ module ConvenientService
               end
 
               class NotExistingStepResultDataAttribute < ConvenientService::Error
-                ##
-                # @internal
-                #   TODO: `step.printable_service`.
-                #
                 def initialize(key:, step:)
                   message = <<~TEXT
-                    Step `#{step.service}` result does NOT return `#{key}` data attribute.
+                    Step `#{step.printable_service}` result does NOT return `#{key}` data attribute.
 
                     Maybe there is a typo in `out` definition?
 
-                    Or `success` of `#{step.service}` accepts a wrong key?
+                    Or `success` of `#{step.printable_service}` accepts a wrong key?
                   TEXT
 
                   super(message)

--- a/lib/convenient_service/service/plugins/has_result_steps/entities/step/concern/instance_methods.rb
+++ b/lib/convenient_service/service/plugins/has_result_steps/entities/step/concern/instance_methods.rb
@@ -70,6 +70,16 @@ module ConvenientService
                   @result ||= calculate_result
                 end
 
+                ##
+                # @return [String]
+                #
+                # @internal
+                #   TODO: printable service for methods steps.
+                #
+                def printable_service
+                  service.klass.to_s
+                end
+
                 def validate!
                   inputs.each { |input| input.validate_as_input_for_container!(container) }
 

--- a/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result/entities/result/plugins/has_jsend_status_and_attributes/entities/data_spec.rb
@@ -28,6 +28,36 @@ RSpec.describe ConvenientService::Service::Plugins::HasResult::Entities::Result:
   end
 
   example_group "instance methods" do
+    describe "#has_attribute?" do
+      context "when `data` has NO attribute by key" do
+        let(:value) { {} }
+
+        it "returns `false`" do
+          expect(data.has_attribute?(:foo)).to eq(false)
+        end
+
+        context "when key is string" do
+          it "converts that key to symbol" do
+            expect(data.has_attribute?("foo")).to eq(false)
+          end
+        end
+      end
+
+      context "when `data` has attribute by key" do
+        let(:value) { {foo: :bar} }
+
+        it "returns `true`" do
+          expect(data.has_attribute?(:foo)).to eq(true)
+        end
+
+        context "when key is string" do
+          it "converts that key to symbol" do
+            expect(data.has_attribute?("foo")).to eq(true)
+          end
+        end
+      end
+    end
+
     describe "#[]" do
       it "returns `data` attribute by string key" do
         expect(data["foo"]).to eq(:bar)

--- a/spec/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_steps/entities/method/commands/define_method_in_container_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Entities::Me
         context "when step is NOT completed" do
           let(:error_message) do
             <<~TEXT
-              `out` method `#{method}` is called before its corresponding step `#{step.service}` is completed.
+              `out` method `#{method}` is called before its corresponding step `#{step.printable_service}` is completed.
 
               Maybe it makes sense to change the steps order?
             TEXT
@@ -113,11 +113,11 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Entities::Me
 
             let(:error_message) do
               <<~TEXT
-                Step `#{step.service}` result does NOT return `#{key}` data attribute.
+                Step `#{step.printable_service}` result does NOT return `#{key}` data attribute.
 
                 Maybe there is a typo in `out` definition?
 
-                Or `success` of `#{step.service}` accepts a wrong key?
+                Or `success` of `#{step.printable_service}` accepts a wrong key?
               TEXT
             end
 

--- a/spec/lib/convenient_service/service/plugins/has_result_steps/entities/step/concern/instance_methods_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_steps/entities/step/concern/instance_methods_spec.rb
@@ -347,6 +347,12 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultSteps::Entities::St
       end
     end
 
+    describe "#printable_service" do
+      it "returns printable service as string" do
+        expect(step.printable_service).to eq(step.service.klass.to_s)
+      end
+    end
+
     describe "#to_args" do
       let(:args_representation) { [step.service] }
 


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

**Preconditions:**

<img width="720" alt="Screenshot 2022-12-26 at 00 50 48" src="https://user-images.githubusercontent.com/22632866/209483913-3b941cef-5597-48e2-95a0-1597ec037de4.png">

<img width="720" alt="Screenshot 2022-12-26 at 00 51 02" src="https://user-images.githubusercontent.com/22632866/209483916-4e76d5d4-c73e-4929-b145-c30172d3b557.png">

<img width="720" alt="Screenshot 2022-12-26 at 00 51 14" src="https://user-images.githubusercontent.com/22632866/209483917-c4db9bca-df79-4c08-8d5d-88e229880809.png">

<img width="720" alt="Screenshot 2022-12-26 at 00 55 14" src="https://user-images.githubusercontent.com/22632866/209483921-6b499db8-6f2b-4387-b8ac-de82b9da6a80.png">

**Before:**

<img width="720" alt="Screenshot 2022-12-26 at 01 02 28" src="https://user-images.githubusercontent.com/22632866/209484044-f8948993-c1ce-4242-a474-49c25a8f31a4.png">

**After:**

<img width="720" alt="Screenshot 2022-12-26 at 00 55 21" src="https://user-images.githubusercontent.com/22632866/209483943-65762ccf-94af-4183-ab49-ce6f9d2f5965.png">

**Try it yourself**:

```ruby
class FirstStep
  include ConvenientService::Standard::Config

  attr_reader :foo

  def initialize(foo:)
    @foo = foo
  end

  def result
    ##
    # NOTE: Must be `bar`.
    #
    success(abc: "abc")
  end
end

class SecondStep
  include ConvenientService::Standard::Config

  attr_reader :bar

  def initialize(bar:)
    @bar = bar
  end

  def result
    success(baz: "baz")
  end
end

class Service
  include ConvenientService::Standard::Config

  attr_reader :foo

  def initialize(foo:)
    @foo = foo
  end

  step FirstStep, in: :foo, out: :bar
  step SecondStep, in: :bar, out: :baz
end

result = Service.result(foo: "foo")
````



## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Easier to figure out the cause of the typo.

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- Introduced `Data#has_attribute?`.

## How to test?

- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
