### PR TITLE
CS-26: RSpec.current_example does NOT exist when RSpec is partially loaded

### DIFF
--- a/lib/convenient_service/support/gems/rspec.rb
+++ b/lib/convenient_service/support/gems/rspec.rb
@@ -34,7 +34,7 @@ module ConvenientService
           # @return [RSpec::Core::Example, nil]
           #
           # @internal
-          #   NOTE: Returns `nil` in a non-test environment
+          #   NOTE: Returns `nil` in environments where RSpec is NOT fully loaded, e.g: irb, rails console, etc.
           #
           #   `::RSpec.current_example` docs:
           #   - https://www.rubydoc.info/github/rspec/rspec-core/RSpec.current_example
@@ -42,7 +42,14 @@ module ConvenientService
           #   - https://relishapp.com/rspec/rspec-core/docs/metadata/current-example
           #
           def current_example
-            ::RSpec.current_example if loaded?
+            return unless loaded?
+
+            ##
+            # NOTE: This happens in Ruby-only projects where RSpec is loaded by `Bundler.require`, not by `bundle exec rspec`.
+            #
+            return unless ::RSpec.respond_to?(:current_example)
+
+            ::RSpec.current_example
           end
         end
       end

--- a/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/can_have_stubbed_result/concern_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ConvenientService::Service::Plugins::CanHaveStubbedResult::Concer
         end
       end
 
-      context "when RSpec is loaded and current example is set" do
+      context "when RSpec current example is set" do
         it "returns cache scoped by self" do
           expect(service_class.stubbed_results).to eq(ConvenientService::Support::Cache.new.scope(service_class))
         end

--- a/spec/lib/convenient_service/support/gems/rspec_spec.rb
+++ b/spec/lib/convenient_service/support/gems/rspec_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ConvenientService::Support::Gems::RSpec do
     end
 
     describe "current_example" do
-      it "returns current_example" do |example|
+      it "returns `current_example`" do |example|
         expect(described_class.current_example).to eq(example)
       end
 
@@ -33,7 +33,17 @@ RSpec.describe ConvenientService::Support::Gems::RSpec do
           allow(described_class).to receive(:loaded?).and_return(false)
         end
 
-        it "returns nil" do
+        it "returns `nil`" do
+          expect(described_class.current_example).to be_nil
+        end
+      end
+
+      context "when `RSpec` does NOT respond to `current_example`" do
+        before do
+          allow(RSpec).to receive(:respond_to?).with(:current_example).and_return(false)
+        end
+
+        it "returns `nil`" do
           expect(described_class.current_example).to be_nil
         end
       end


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Fixed the following issue:

  <img width="720" alt="Screenshot 2022-12-26 at 02 21 39" src="https://user-images.githubusercontent.com/22632866/209485708-46befe68-0d4d-47a6-a6aa-1f97b17ac357.png">

  <img width="720" alt="Screenshot 2022-12-26 at 02 21 52" src="https://user-images.githubusercontent.com/22632866/209485716-6411a0b4-0e6d-4010-a1a6-b9eb6d38f96a.png">


- **Try it yourself:**
  ```bash
  task playground
  ```

  ```ruby
  class Service
    include ConvenientService::Standard::Config

    attr_reader :foo

    def initialize(foo:)
      @foo = foo
    end

    def result
       success(bar: "bar")
    end
  end

  result = Service.result(foo: "foo")
  ```

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Services can be debugged in a playground.

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- `RSpec.respond_to?(:current_example)`

## How to test?

- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
