### PR TITLE
CS-30: Replace `self.included` with `included` 

### DIFF
--- a/lib/convenient_service.rb
+++ b/lib/convenient_service.rb
@@ -29,3 +29,9 @@ require_relative "convenient_service/core"
 require_relative "convenient_service/common"
 require_relative "convenient_service/service"
 require_relative "convenient_service/configs"
+
+##
+# @internal
+#   Convenient Service Aliases.
+#
+require_relative "convenient_service/aliases"

--- a/lib/convenient_service/aliases.rb
+++ b/lib/convenient_service/aliases.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  Concern = ::ConvenientService::Support::Concern
+end

--- a/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
+++ b/lib/convenient_service/examples/dry/gemfile/dry_service/config.rb
@@ -12,7 +12,9 @@ module ConvenientService
       module Gemfile
         class DryService
           module Config
-            def self.included(service_class)
+            include Support::Concern
+
+            included do |service_class|
               service_class.class_exec do
                 include Configs::Standard
 

--- a/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
+++ b/lib/convenient_service/examples/rails/gemfile/rails_service/config.rb
@@ -12,7 +12,9 @@ module ConvenientService
       module Gemfile
         class RailsService
           module Config
-            def self.included(service_class)
+            include Support::Concern
+
+            included do |service_class|
               service_class.class_exec do
                 include Configs::Standard
 

--- a/spec/lib/convenient_service/aliases_spec.rb
+++ b/spec/lib/convenient_service/aliases_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "convenient_service/aliases" do
+  specify { expect(ConvenientService::Concerns).to eq(ConvenientService::Support::Concern) }
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/convenient_service/aliases_spec.rb
+++ b/spec/lib/convenient_service/aliases_spec.rb
@@ -6,6 +6,6 @@ require "convenient_service"
 
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "convenient_service/aliases" do
-  specify { expect(ConvenientService::Concerns).to eq(ConvenientService::Support::Concern) }
+  specify { expect(ConvenientService::Concern).to eq(ConvenientService::Support::Concern) }
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/lib/convenient_service/examples/dry/gemfile/dry_service/config_spec.rb
+++ b/spec/lib/convenient_service/examples/dry/gemfile/dry_service/config_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ConvenientService::Examples::Dry::Gemfile::DryService::Config do
 
     subject { described_class }
 
+    specify { expect(described_class).to include_module(ConvenientService::Support::Concern) }
+
     context "when included" do
       let(:service_class) do
         Class.new.tap do |klass|

--- a/spec/lib/convenient_service/examples/rails/gemfile/rails_service/config_spec.rb
+++ b/spec/lib/convenient_service/examples/rails/gemfile/rails_service/config_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ConvenientService::Examples::Rails::Gemfile::RailsService::Config
 
     subject { described_class }
 
+    specify { expect(described_class).to include_module(ConvenientService::Support::Concern) }
+
     context "when included" do
       let(:service_class) do
         Class.new.tap do |klass|


### PR DESCRIPTION
## What was done as a part of this PR?
- Replaced `self.included` in configs with `included`
- Created an alias for `ConvenientService::Support::Concern`
- Spec for new alias

## Why it was done?
- To avoid  uncontrollable `concerns` and `middlewarws` appendment

## How it was done?
- Replaced `self.included` with `included`

## How to test?

- `task rspec -- spec/lib/convenient_service/aliases_spec.rb`
- `task rspec:dry -- spec/lib/convenient_service/examples/dry/gemfile/dry_service/config_spec.rb`
- `task rspec:rails_7.0 -- spec/lib/convenient_service/examples/rails/gemfile/rails_service/config_spec.rb`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Notes

You can find more information in this [discussion](https://github.com/marian13/convenient_service/discussions/43)

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
