### PR TITLE
CS-32: Fix typo in `dependency_container`

### DIFF
--- a/lib/convenient_service/support/dependency_container/errors.rb
+++ b/lib/convenient_service/support/dependency_container/errors.rb
@@ -56,7 +56,7 @@ module ConvenientService
             message = <<~TEXT
               Module `#{mod}` does NOT export method `#{method_name}` with `#{method_scope}` scope.
 
-              Did you forget to export if from `#{mod}`? For example:
+              Did you forget to export it from `#{mod}`? For example:
 
               module #{mod}
                 export #{method_name}, scope: :#{method_scope} do |*args, **kwargs, &block|

--- a/spec/lib/convenient_service/support/dependency_container/import_spec.rb
+++ b/spec/lib/convenient_service/support/dependency_container/import_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ConvenientService::Support::DependencyContainer::Import do
             <<~TEXT
               Module `#{container}` does NOT export method `#{full_name}` with `#{scope}` scope.
 
-              Did you forget to export if from `#{container}`? For example:
+              Did you forget to export it from `#{container}`? For example:
 
               module #{container}
                 export #{full_name}, scope: :#{scope} do |*args, **kwargs, &block|


### PR DESCRIPTION
## What was done as a part of this PR?
- Fixed typo in the error message

## Why it was done?
- To keep all the messages without typos

## How it was done?
- Replaced wrong `if` in `...Did you forget to export if from `#{container}`? For example:...`  with `it` `...Did you forget to export it from `#{container}`? For example:...`

## How to test?

- `task rspec --spec/lib/convenient_service/support/dependency_container/import_spec.rb`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
