### PR TITLE
CS-35: Fix typo in `be_direct_descendant_of` and `be_descendant_of`

### DIFF
--- a/convenient_service.gemspec
+++ b/convenient_service.gemspec
@@ -49,6 +49,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"
   spec.add_development_dependency "webrick"
-  spec.add_development_dependency "yard"
+  spec.add_development_dependency "yard", "~> 0.9.28"
   spec.add_development_dependency "yard-junk"
 end

--- a/lib/convenient_service/rspec/matchers/custom/be_descendant_of.rb
+++ b/lib/convenient_service/rspec/matchers/custom/be_descendant_of.rb
@@ -30,7 +30,7 @@ module ConvenientService
           end
 
           ##
-          # NOTE: `failure_message` is only called when `mathces?` returns `false`.
+          # NOTE: `failure_message` is only called when `matches?` returns `false`.
           # https://rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers/MatcherProtocol#failure_message-instance_method
           #
           def failure_message
@@ -38,7 +38,7 @@ module ConvenientService
           end
 
           ##
-          # NOTE: `failure_message_when_negated` is only called when `mathces?` returns `false`.
+          # NOTE: `failure_message_when_negated` is only called when `matches?` returns `false`.
           # https://rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers/MatcherProtocol#failure_message-instance_method
           #
           def failure_message_when_negated

--- a/lib/convenient_service/rspec/matchers/custom/be_direct_descendant_of.rb
+++ b/lib/convenient_service/rspec/matchers/custom/be_direct_descendant_of.rb
@@ -30,7 +30,7 @@ module ConvenientService
           end
 
           ##
-          # NOTE: `failure_message` is only called when `mathces?` returns `false`.
+          # NOTE: `failure_message` is only called when `matches?` returns `false`.
           # https://rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers/MatcherProtocol#failure_message-instance_method
           #
           def failure_message
@@ -38,7 +38,7 @@ module ConvenientService
           end
 
           ##
-          # NOTE: `failure_message_when_negated` is only called when `mathces?` returns `false`.
+          # NOTE: `failure_message_when_negated` is only called when `matches?` returns `false`.
           # https://rubydoc.info/github/rspec/rspec-expectations/RSpec/Matchers/MatcherProtocol#failure_message-instance_method
           #
           def failure_message_when_negated


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Fixed typo in the comments

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- To keep all the comments without typos

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

- Replaced `mathces` with `matches`

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
