### PR TITLE
CS-37: Implement a logic that forbids to use `export` in classes 

### DIFF
--- a/lib/convenient_service/support/dependency_container/errors.rb
+++ b/lib/convenient_service/support/dependency_container/errors.rb
@@ -75,7 +75,9 @@ module ConvenientService
           # @return [void]
           #
           def initialize(klass:)
-            message = "#{klass} is NOT a Module."
+            message = <<~TEXT
+              `#{klass.inspect}` is NOT a Module.
+            TEXT
 
             super(message)
           end

--- a/lib/convenient_service/support/dependency_container/errors.rb
+++ b/lib/convenient_service/support/dependency_container/errors.rb
@@ -68,6 +68,18 @@ module ConvenientService
             super(message)
           end
         end
+
+        class NotModule < ConvenientService::Error
+          ##
+          # @param klass [Class]
+          # @return [void]
+          #
+          def initialize(klass:)
+            message = "#{klass} is NOT a Module."
+
+            super(message)
+          end
+        end
       end
     end
   end

--- a/lib/convenient_service/support/dependency_container/export.rb
+++ b/lib/convenient_service/support/dependency_container/export.rb
@@ -6,6 +6,14 @@ module ConvenientService
       module Export
         include Support::Concern
 
+        ##
+        # @param klass [Class, Module]
+        # @return [Module]
+        #
+        included do |klass|
+          raise Errors::NotModule.new(klass: klass) unless klass.instance_of?(Module)
+        end
+
         class_methods do
           ##
           # @param full_name [String, Symbol]

--- a/lib/convenient_service/support/dependency_container/export.rb
+++ b/lib/convenient_service/support/dependency_container/export.rb
@@ -11,7 +11,7 @@ module ConvenientService
         # @return [Module]
         #
         included do |klass|
-          raise Errors::NotModule.new(klass: klass) unless klass.instance_of?(Module)
+          raise Errors::NotModule.new(klass: klass) unless klass.instance_of?(::Module)
         end
 
         class_methods do

--- a/spec/lib/convenient_service/support/dependency_container/export_spec.rb
+++ b/spec/lib/convenient_service/support/dependency_container/export_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ConvenientService::Support::DependencyContainer::Export do
   include ConvenientService::RSpec::Matchers::DelegateTo
 
   let(:container) do
-    Class.new.tap do |klass|
-      klass.class_exec(described_class) do |mod|
-        include mod
+    Module.new.tap do |mod|
+      mod.module_exec(described_class) do |described_mod|
+        include described_mod
       end
     end
   end
@@ -32,6 +32,32 @@ RSpec.describe ConvenientService::Support::DependencyContainer::Export do
     subject { described_class }
 
     it { is_expected.to include_module(ConvenientService::Support::Concern) }
+  end
+
+  example_group "hook methods" do
+    describe "#included" do
+      context "when container is NOT Module" do
+        let(:container) { Class.new }
+        let(:include_module_result) { container.include described_class }
+
+        let(:error_message) { "#{container} is NOT a Module." }
+
+        it "raises `ConvenientService::Support::DependencyContainer::Errors::NotModule`" do
+          expect { include_module_result }
+            .to raise_error(ConvenientService::Support::DependencyContainer::Errors::NotModule)
+            .with_message(error_message)
+        end
+      end
+
+      context "when container is Module" do
+        let(:container) { Module.new }
+        let(:include_module_result) { container.include described_class }
+
+        it "does NOT raise" do
+          expect { include_module_result }.not_to raise_error
+        end
+      end
+    end
   end
 
   example_group "class methods" do

--- a/spec/lib/convenient_service/support/dependency_container/export_spec.rb
+++ b/spec/lib/convenient_service/support/dependency_container/export_spec.rb
@@ -36,25 +36,20 @@ RSpec.describe ConvenientService::Support::DependencyContainer::Export do
 
   example_group "hook methods" do
     describe "#included" do
-      context "when container is NOT Module" do
+      context "when container is NOT `Module`" do
         let(:container) { Class.new }
         let(:include_module_result) { container.include described_class }
 
-        let(:error_message) { "#{container} is NOT a Module." }
+        let(:error_message) do
+          <<~TEXT
+            `#{container.inspect}` is NOT a Module.
+          TEXT
+        end
 
         it "raises `ConvenientService::Support::DependencyContainer::Errors::NotModule`" do
           expect { include_module_result }
             .to raise_error(ConvenientService::Support::DependencyContainer::Errors::NotModule)
             .with_message(error_message)
-        end
-      end
-
-      context "when container is Module" do
-        let(:container) { Module.new }
-        let(:include_module_result) { container.include described_class }
-
-        it "does NOT raise" do
-          expect { include_module_result }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Added a restriction on to use of `export` in classes.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Ask @marian13 

## How to test?

- `task rspec -- spec/lib/convenient_service/support/dependency_container/export_spec.rb`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Notes
<!--- Additional info, links, screenshots, actually anything that helps to recreate the way of thoughts (optional). -->
- Now using `export` is only allowed in Module.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
