### PR TITLE
Introduce RescuesResultUnhandledExceptions plugin

### DIFF
--- a/lib/convenient_service/dependencies.rb
+++ b/lib/convenient_service/dependencies.rb
@@ -77,6 +77,14 @@ module ConvenientService
 
       ##
       # @return [Boolean]
+      # @note Expected to be called from app entry points like `initializers` in Rails.
+      #
+      def require_rescues_result_unhandled_exceptions
+        require_relative "service/plugins/rescues_result_unhandled_exceptions"
+      end
+
+      ##
+      # @return [Boolean]
       # @note Expected to be called from `irb`, `pry`, `spec_helper.rb`, etc.
       #
       def require_development_tools

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "rescues_result_unhandled_exceptions/commands"
+require_relative "rescues_result_unhandled_exceptions/constants"
+require_relative "rescues_result_unhandled_exceptions/middleware"

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "commands/format_backtrace"
+require_relative "commands/format_cause"
+require_relative "commands/format_line"
+
+require_relative "commands/format_exception"

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_backtrace.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_backtrace.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  module Service
+    module Plugins
+      module RescuesResultUnhandledExceptions
+        module Commands
+          class FormatBacktrace < Support::Command
+            ##
+            # @!attribute [r] backtrace
+            #   @return [Array, nil]
+            #
+            attr_reader :backtrace
+
+            ##
+            # @!attribute [r] max_size
+            #   @return [Integer]
+            #
+            attr_reader :max_size
+
+            ##
+            # @param backtrace [Array, nil]
+            # @param max_size [Integer]
+            # @return [void]
+            #
+            # @internal
+            #   IMPORTANT: Sometimes `exception.backtrace` can be `nil`.
+            #   - https://blog.kalina.tech/2019/04/exception-without-backtrace-in-ruby.html
+            #   - https://github.com/jruby/jruby/issues/4467
+            #
+            def initialize(backtrace:, max_size:)
+              @backtrace = backtrace.to_a
+              @max_size = max_size
+            end
+
+            ##
+            # @return [String]
+            #
+            # @note Exceptions formatting is inspired by RSpec. It has almost the same output (at least for RSpec 3).
+            #
+            # @example Backtrace with upto 10 lines.
+            #
+            #   # /gem/lib/convenient_service/factories/services.rb:120:in `result'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/caller/commands/define_method_middlewares_caller.rb:116:in `call'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/caller/commands/define_method_middlewares_caller.rb:116:in `block in result'
+            #   # /gem/lib/convenient_service/dependencies/extractions/ruby_middleware/middleware/runner.rb:67:in `block (2 levels) in build_call_chain'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/chain.rb:35:in `next'
+            #   # /gem/lib/convenient_service/common/plugins/caches_return_value/middleware.rb:17:in `block in next'
+            #   # /gem/lib/convenient_service/support/cache.rb:110:in `fetch'
+            #   # /gem/lib/convenient_service/common/plugins/caches_return_value/middleware.rb:17:in `next'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/middleware.rb:73:in `call'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/chain.rb:35:in `next'
+            #
+            # @example Backtrace with more than 10 lines.
+            #
+            #   # /gem/lib/convenient_service/factories/services.rb:120:in `result'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/caller/commands/define_method_middlewares_caller.rb:116:in `call'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/caller/commands/define_method_middlewares_caller.rb:116:in `block in result'
+            #   # /gem/lib/convenient_service/dependencies/extractions/ruby_middleware/middleware/runner.rb:67:in `block (2 levels) in build_call_chain'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/chain.rb:35:in `next'
+            #   # /gem/lib/convenient_service/common/plugins/caches_return_value/middleware.rb:17:in `block in next'
+            #   # /gem/lib/convenient_service/support/cache.rb:110:in `fetch'
+            #   # /gem/lib/convenient_service/common/plugins/caches_return_value/middleware.rb:17:in `next'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/middleware.rb:73:in `call'
+            #   # /gem/lib/convenient_service/core/entities/config/entities/method_middlewares/entities/chain.rb:35:in `next'
+            #   # ...
+            #
+            def call
+              message = backtrace.take(max_size).map { |line| Commands::FormatLine.call(line: line) }.join("\n")
+
+              message << "\n# ..." if backtrace.size > max_size
+
+              message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_cause.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_cause.rb
@@ -41,7 +41,7 @@ module ConvenientService
                 --- Caused by: ---
                 #{cause.class}:
                   #{cause.message}
-                #{formatted_first_line}
+                #{formatted_cause_first_line}
               MESSAGE
             end
 
@@ -55,7 +55,7 @@ module ConvenientService
             #   - https://blog.kalina.tech/2019/04/exception-without-backtrace-in-ruby.html
             #   - https://github.com/jruby/jruby/issues/4467
             #
-            def first_line
+            def cause_first_line
               return "" unless cause
               return "" unless cause.backtrace
 
@@ -65,10 +65,10 @@ module ConvenientService
             ##
             # @return [String, nil]
             #
-            def formatted_first_line
-              return "" unless first_line
+            def formatted_cause_first_line
+              return "" unless cause_first_line
 
-              Commands::FormatLine.call(line: first_line)
+              Commands::FormatLine.call(line: cause_first_line)
             end
           end
         end

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_cause.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_cause.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  module Service
+    module Plugins
+      module RescuesResultUnhandledExceptions
+        module Commands
+          class FormatCause < Support::Command
+            ##
+            # @!attribute [r] exception
+            #   @return [StandardError, nil]
+            #
+            attr_reader :cause
+
+            ##
+            # @param cause [StandardError]
+            # @return [void]
+            #
+            def initialize(cause:)
+              @cause = cause
+            end
+
+            ##
+            # @return [String]
+            #
+            # @note Cause formatting is inspired by RSpec. It has almost the same output (at least for RSpec 3).
+            #
+            # @example Cause.
+            #
+            #   ------------------
+            #   --- Caused by: ---
+            #   StandardError:
+            #     cause message
+            #   # /gem/lib/convenient_service/factories/service/class.rb:41:in `result'
+            #
+            def call
+              return "" unless cause
+
+              <<~MESSAGE.chomp
+                ------------------
+                --- Caused by: ---
+                #{cause.class}:
+                  #{cause.message}
+                #{formatted_first_line}
+              MESSAGE
+            end
+
+            private
+
+            ##
+            # @return [String, nil]
+            #
+            # @internal
+            #   IMPORTANT: Sometimes `exception.backtrace` can be `nil`.
+            #   - https://blog.kalina.tech/2019/04/exception-without-backtrace-in-ruby.html
+            #   - https://github.com/jruby/jruby/issues/4467
+            #
+            def first_line
+              return "" unless cause
+              return "" unless cause.backtrace
+
+              cause.backtrace.first
+            end
+
+            ##
+            # @return [String, nil]
+            #
+            def formatted_first_line
+              return "" unless first_line
+
+              Commands::FormatLine.call(line: first_line)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_line.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_line.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  module Service
+    module Plugins
+      module RescuesResultUnhandledExceptions
+        module Commands
+          class FormatLine < Support::Command
+            ##
+            # @!attribute [r] line
+            #   @return [String]
+            #
+            attr_reader :line
+
+            ##
+            # @param line [String]
+            # @return [void]
+            #
+            def initialize(line:)
+              @line = line
+            end
+
+            ##
+            # @return [String]
+            #
+            # @note Exceptions formatting is inspired by RSpec. It has almost the same output (at least for RSpec 3).
+            #
+            # @example Line.
+            #
+            #   # /gem/lib/convenient_service/factories/services.rb:120:in `result'
+            #
+            def call
+              "# #{line}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/constants.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/constants.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  module Service
+    module Plugins
+      module RescuesResultUnhandledExceptions
+        module Constants
+          DEFAULT_MAX_BACKTRACE_SIZE = 10
+        end
+      end
+    end
+  end
+end

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware.rb
@@ -35,7 +35,10 @@ module ConvenientService
           # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result]
           #
           def failure_result_from(exception, *args, **kwargs, &block)
-            entity.failure(data: {exception: format_exception(exception, *args, **kwargs, &block)})
+            entity.failure(
+              data: {exception: exception},
+              message: format_exception(exception, *args, **kwargs, &block)
+            )
           end
 
           ##

--- a/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware.rb
+++ b/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module ConvenientService
+  module Service
+    module Plugins
+      module RescuesResultUnhandledExceptions
+        class Middleware < Core::MethodChainMiddleware
+          ##
+          # @param args [Array]
+          # @param kwargs [Hash]
+          # @param block [Proc, nil]
+          # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result]
+          #
+          # @internal
+          #   NOTE: `rescue => exception` is the same as `rescue ::StandardError => exception`.
+          #
+          #   IMPORTANT: Never rescue `Exception` since its direct descendants are used internally by Ruby, rescue `StandardError` instead.
+          #   - https://thoughtbot.com/blog/rescue-standarderror-not-exception
+          #   - https://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby
+          #   - https://ruby-doc.org/core-2.7.0/Exception.html
+          #
+          def next(*args, **kwargs, &block)
+            chain.next(*args, **kwargs, &block)
+          rescue => exception
+            failure_result_from(exception, *args, **kwargs, &block)
+          end
+
+          private
+
+          ##
+          # @param exception [StandardError]
+          # @param args [Array]
+          # @param kwargs [Hash]
+          # @param block [Proc, nil]
+          # @return [ConvenientService::Service::Plugins::HasResult::Entities::Result]
+          #
+          def failure_result_from(exception, *args, **kwargs, &block)
+            entity.failure(data: {exception: format_exception(exception, *args, **kwargs, &block)})
+          end
+
+          ##
+          # @param exception [StandardError]
+          # @param args [Array]
+          # @param kwargs [Hash]
+          # @param block [Proc, nil]
+          # @return [String]
+          #
+          def format_exception(exception, *args, **kwargs, &block)
+            Commands::FormatException.call(exception: exception, args: args, kwargs: kwargs, block: block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_exception_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_exception_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+# rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+RSpec.describe ConvenientService::Service::Plugins::RescuesResultUnhandledExceptions::Commands::FormatException do
+  example_group "class methods" do
+    describe ".call" do
+      subject(:command_result) { described_class.call(exception: exception, args: args, kwargs: kwargs, block: block) }
+
+      let(:exception) do
+        service_class.result(*args, **kwargs, &block)
+      rescue => error
+        error
+      end
+
+      let(:args) { [:foo] }
+      let(:kwargs) { {foo: :bar} }
+      let(:block) { proc { :foo } }
+
+      context "when exception has NO backtrace" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              ##
+              # NOTE: Sometimes exceptions may have no backtrace, especially when they are created by developers manually, NOT by Ruby internals.
+              #   - https://blog.kalina.tech/2019/04/exception-without-backtrace-in-ruby.html
+              #   - https://github.com/jruby/jruby/issues/4467
+              #
+              # NOTE: Check the following tricky behaviour, it explains why an empty array is passed.
+              #   `raise StandardError, "exception message", nil` ignores `nil` and still generates full backtrace.
+              #   `raise StandardError, "exception message", []` generates no backtrace, but `exception.backtrace` returns `nil`.
+              #
+              raise StandardError, "exception message", []
+            end
+          end
+        end
+
+        let(:formatted_exception) do
+          <<~MESSAGE.chomp
+            #{exception.class}:
+              #{exception.message}
+          MESSAGE
+        end
+
+        it "returns formatted exception with full backtrace" do
+          expect(command_result).to eq(formatted_exception)
+        end
+      end
+
+      context "when exception has backtrace with short backtrace" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              raise StandardError, "exception message", caller.take(10)
+            end
+          end
+        end
+
+        let(:formatted_exception) do
+          <<~MESSAGE.chomp
+            #{exception.class}:
+              #{exception.message}
+            #{exception.backtrace.map { |line| "# #{line}" }.join("\n")}
+          MESSAGE
+        end
+
+        it "returns formatted exception with full backtrace" do
+          expect(command_result).to eq(formatted_exception)
+        end
+      end
+
+      context "when exception has backtrace with long backtrace" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              raise StandardError, "exception message", caller + ["# /line.rb:1:in `foo'"] * 10
+            end
+          end
+        end
+
+        let(:formatted_exception) do
+          <<~MESSAGE.chomp
+            #{exception.class}:
+              #{exception.message}
+            #{exception.backtrace.take(10).map { |line| "# #{line}" }.join("\n")}
+            # ...
+          MESSAGE
+        end
+
+        it "returns formatted exception with trimmed backtrace" do
+          expect(command_result).to eq(formatted_exception)
+        end
+      end
+
+      context "when exception has cause" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              raise StandardError, "cause message"
+            rescue
+              raise StandardError, "exception message"
+            end
+          end
+        end
+
+        let(:formatted_exception) do
+          <<~MESSAGE.chomp
+            #{exception.class}:
+              #{exception.message}
+            #{exception.backtrace.take(10).map { |line| "# #{line}" }.join("\n")}
+            # ...
+            ------------------
+            --- Caused by: ---
+            #{exception.cause.class}:
+              #{exception.cause.message}
+            # #{exception.cause.backtrace.first}
+          MESSAGE
+        end
+
+        it "returns formatted exception with cause" do
+          expect(command_result).to eq(formatted_exception)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_line_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/commands/format_line_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+# rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+RSpec.describe ConvenientService::Service::Plugins::RescuesResultUnhandledExceptions::Commands::FormatLine do
+  example_group "class methods" do
+    describe ".call" do
+      subject(:command_result) { described_class.call(line: line) }
+
+      let(:line) { "/gem/lib/convenient_service/factories/services.rb:120:in `result'" }
+      let(:formatted_line) { "# #{line}" }
+
+      it "returns formatted line" do
+        expect(command_result).to eq(formatted_line)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/constants_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/constants_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+RSpec.describe ConvenientService::Service::Plugins::RescuesResultUnhandledExceptions::Constants do
+  example_group "constants" do
+    describe "DEFAULT_MAX_BACKTRACE_SIZE" do
+      it "returns `10`" do
+        expect(described_class::DEFAULT_MAX_BACKTRACE_SIZE).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ConvenientService::Service::Plugins::RescuesResultUnhandledExcept
         end
 
         it "returns failure with formatted exception" do
-          expect(method_value).to be_failure.with_data(exception: formatted_exception)
+          expect(method_value).to be_failure.with_data(exception: exception).and_message(formatted_exception)
         end
       end
     end

--- a/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/rescues_result_unhandled_exceptions/middleware_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "convenient_service"
+
+# rubocop:disable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers
+RSpec.describe ConvenientService::Service::Plugins::RescuesResultUnhandledExceptions::Middleware do
+  example_group "inheritance" do
+    include ConvenientService::RSpec::Matchers::BeDescendantOf
+
+    subject { described_class }
+
+    it { is_expected.to be_descendant_of(ConvenientService::Core::MethodChainMiddleware) }
+  end
+
+  example_group "instance methods" do
+    describe "#call" do
+      include ConvenientService::RSpec::Helpers::WrapMethod
+
+      include ConvenientService::RSpec::Matchers::CallChainNext
+      include ConvenientService::RSpec::Matchers::DelegateTo
+      include ConvenientService::RSpec::Matchers::Results
+
+      subject(:method_value) { method.call(*args, **kwargs, &block) }
+
+      let(:method) { wrap_method(service_class, :result, middlewares: described_class) }
+
+      let(:args) { [:foo] }
+      let(:kwargs) { {foo: :bar} }
+      let(:block) { proc { :foo } }
+
+      context "when service result does NOT raise exceptions" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              success
+            end
+          end
+        end
+
+        specify do
+          expect { method_value }
+            .to call_chain_next.on(method)
+            .with_arguments(*args, **kwargs, &block)
+            .and_return_its_value
+        end
+      end
+
+      context "when service result raises exceptions" do
+        let(:service_class) do
+          Class.new do
+            include ConvenientService::Configs::Minimal
+
+            def result
+              raise StandardError, "exception message", caller.take(10)
+            end
+          end
+        end
+
+        let(:exception) do
+          service_class.result(*args, **kwargs, &block)
+        rescue => error
+          error
+        end
+
+        let(:formatted_exception) do
+          <<~MESSAGE.chomp
+            #{exception.class}:
+              #{exception.message}
+            #{exception.backtrace.map { |line| "# #{line}" }.join("\n")}
+          MESSAGE
+        end
+
+        specify do
+          expect { method_value }
+            .to call_chain_next.on(method)
+            .with_arguments(*args, **kwargs, &block)
+        end
+
+        specify do
+          expect { method_value }
+            .to delegate_to(ConvenientService::Service::Plugins::RescuesResultUnhandledExceptions::Commands::FormatException, :call)
+            .with_arguments(exception: exception, args: args, kwargs: kwargs, block: block)
+        end
+
+        it "returns failure with formatted exception" do
+          expect(method_value).to be_failure.with_data(exception: formatted_exception)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/NestedGroups, RSpec/MultipleMemoizedHelpers

--- a/spec/support/convenient_service.rb
+++ b/spec/support/convenient_service.rb
@@ -7,6 +7,8 @@ require_relative "../../lib/convenient_service/dependencies/extractions/b"
 
 require "convenient_service"
 
+ConvenientService::Dependencies.require_rescues_result_unhandled_exceptions
+
 ConvenientService::Dependencies.require_rspec_extentions
 ConvenientService::Dependencies.require_factory
 ConvenientService::Dependencies.require_development_tools


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Added a new plugin that rescues all result unhandled exceptions and returns failure.
  ```ruby
  module RescuesResultUnhandledExceptions
    class Middleware < Core::MethodChainMiddleware
      def next(*args, **kwargs, &block)
        chain.next(*args, **kwargs, &block)
      rescue => exception
        failure_result_from(exception, *args, **kwargs, &block)
      end
      # ...
    end
  end
  ```

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

-

## How it was done?
<!--- Useful when a solution is not obvious (seems too extraordinary or too heavy) for a team you work with (optional). -->

-

## How to test?

- `task rspec -- corresponding_spec.rb`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Notes
<!--- Additional info, links, screenshots, actually anything that helps to recreate the way of thoughts (optional). -->

-

## Checklist:

- [ ] I have performed a self-review of my code.
- [ ] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [ ] CI is green.
