### PR TITLE
CS-42: Aliases for `success?` and `not_success?` methods

### DIFF
--- a/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern.rb
+++ b/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern.rb
@@ -58,13 +58,19 @@ module ConvenientService
 
             ##
             # @return [Boolean]
+            # @since 0.12.0
             #
-            alias ok? success?
+            def ok?(...)
+              result(...).success?
+            end
 
             ##
             # @return [Boolean]
+            # @since 0.12.0
             #
-            alias not_ok? not_success?
+            def not_ok?(...)
+              result(...).not_success?
+            end
           end
         end
       end

--- a/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern.rb
+++ b/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern.rb
@@ -55,6 +55,16 @@ module ConvenientService
             def not_failure?(...)
               result(...).not_failure?
             end
+
+            ##
+            # @return [Boolean]
+            #
+            alias ok? success?
+
+            ##
+            # @return [Boolean]
+            #
+            alias not_ok? not_success?
           end
         end
       end

--- a/spec/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern/class_methods_spec.rb
+++ b/spec/lib/convenient_service/service/plugins/has_result_status_check_short_syntax/concern/class_methods_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultStatusCheckShortSyn
       end
     end
 
+    describe ".ok?" do
+      specify do
+        expect { service_class.ok? }
+          .to delegate_to(result, :success?)
+          .and_return_its_value
+      end
+    end
+
     describe ".error?" do
       specify do
         expect { service_class.error? }
@@ -74,6 +82,14 @@ RSpec.describe ConvenientService::Service::Plugins::HasResultStatusCheckShortSyn
       specify do
         expect { service_class.failure? }
           .to delegate_to(result, :failure?)
+          .and_return_its_value
+      end
+    end
+
+    describe ".not_ok?" do
+      specify do
+        expect { service_class.not_ok? }
+          .to delegate_to(result, :not_success?)
           .and_return_its_value
       end
     end


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Added alias methods `ok?` - `success?`, `not_ok?` - `not_success?`
- Added specs for the `ok?`, `not_ok?` methods.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- To have the ability to call `ok?`, `not_ok?` as a shorter and more intuitive form of methods `success?`, `not_success`.
  #### Two new ways to check status
  ```ruby 
  Service.ok?(**kwargs)
  Service.not_ok?(**kwargs)
  ```

## How to test?

- Use the following command:
  ```ruby
  task rspec -- spec/lib/convenient_service/service/plugins/has_result_status_check_short_syntax
  ```

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
