### PR TITLE
CS-21: Support ruby 3.2 in CI and Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           ##
           # NOTE: Installs the latest compatible Bundler version, runs `bundle install` and caches installed gems.
           # - https://github.com/ruby/setup-ruby#usage
@@ -101,6 +101,7 @@ jobs:
           #
           - "3.0"
           - 3.1
+          - 3.2
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in convenient_service.gemspec
 gemspec
+
+group :development, :test do
+  gem "appraisal", github: "thoughtbot/appraisal"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "appraisal", github: "thoughtbot/appraisal"
+  # NOTE: Temporarily pointing appraisal at the commit in the main branch until the following issue is resolved:
+  # https://github.com/thoughtbot/appraisal/issues/199
+  gem "appraisal", github: "thoughtbot/appraisal", ref: "b200e636903700098bef25f4f51dbc4c46e4c04c"
 end

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,11 +67,20 @@ tasks:
       - sh: '[ "${IN_DOCKER_CONTAINER}" != "true" ]'
         msg: This task can be invoked only from the host operating system (https://www.ibm.com/cloud/learn/containerization)
 
+  docker:bash:ruby_3.2:
+    cmds:
+      - docker run --rm -it -v $(pwd):/gem convenient_service:3.2 bash
+    interactive: true
+    preconditions:
+      - sh: '[ "${IN_DOCKER_CONTAINER}" != "true" ]'
+        msg: This task can be invoked only from the host operating system (https://www.ibm.com/cloud/learn/containerization)
+
   docker:build:
     cmds:
       - task: docker:build:ruby_2.7
       - task: docker:build:ruby_3.0
       - task: docker:build:ruby_3.1
+      - task: docker:build:ruby_3.2
     preconditions:
       - sh: '[ "${IN_DOCKER_CONTAINER}" != "true" ]'
         msg: This task can be invoked only from the host operating system (https://www.ibm.com/cloud/learn/containerization)
@@ -123,6 +132,23 @@ tasks:
       - rm Gemfile.3.1.lock 2> /dev/null || true
       - cp Gemfile Gemfile.3.1
       - docker build . -f docker/3.1/Dockerfile -t convenient_service:3.1
+    preconditions:
+      - sh: '[ "${IN_DOCKER_CONTAINER}" != "true" ]'
+        msg: This task can be invoked only from the host operating system (https://www.ibm.com/cloud/learn/containerization)
+
+  docker:build:ruby_3.2:
+    cmds:
+      ##
+      # NOTE: Meaning of `|| 2> /dev/null`.
+      # https://stackoverflow.com/a/10250395/12201472
+      #
+      # NOTE: Meaning of `|| true`.
+      # https://superuser.com/a/887349/1180656
+      #
+      - rm Gemfile.3.2 2> /dev/null || true
+      - rm Gemfile.3.2.lock 2> /dev/null || true
+      - cp Gemfile Gemfile.3.2
+      - docker build . -f docker/3.2/Dockerfile -t convenient_service:3.2
     preconditions:
       - sh: '[ "${IN_DOCKER_CONTAINER}" != "true" ]'
         msg: This task can be invoked only from the host operating system (https://www.ibm.com/cloud/learn/containerization)

--- a/docker/3.2/Dockerfile
+++ b/docker/3.2/Dockerfile
@@ -1,0 +1,73 @@
+##
+# Ruby 3.2 with Node.js 16.x.
+#
+# NOTE: Linted by hadolint.
+#
+#   docker run --rm -i ghcr.io/hadolint/hadolint < docker/3.2/Dockerfile
+#
+# NOTE: A command to build image.
+#
+#   cd convenient_service
+#   cp Gemfile Gemfile.3.2
+#   docker build . -f docker/3.2/Dockerfile -t convenient_service:3.2
+#   # or `task docker:build:ruby_3.2`
+#
+# NOTE: A command to run bash in container.
+#
+#   cd convenient_service
+#   docker run --rm -it -v $(pwd):/gem convenient_service:3.2 bash
+#   # or `task docker:bash:ruby_3.2`
+#
+# NOTE: If there are no memory, performance, or cost constraints, prefer to use as standard Linux distribution as it is possible.
+# In a general case, you simply won't have enough time to resolve all the "quirks" of more specific distributions if you are an application developer.
+# That is why a `slim` version is used instead of `alpine`.
+# Also `slim` is more similar to Ubuntu used in CI.
+# - https://github.com/timbru31/docker-ruby-node/tree/master/3.2/16
+# - https://medium.com/swlh/alpine-slim-stretch-buster-jessie-bullseye-bookworm-what-are-the-differences-in-docker-62171ed4531d
+# - https://hub.docker.com/r/timbru31/ruby-node/tags
+#
+# NOTE: Gallium means Node.js 16.x
+# https://github.com/nodejs/Release
+#
+FROM timbru31/ruby-node:3.2-slim-gallium
+
+##
+# NOTE: `bundle install` dependencies.
+#
+RUN apt-get update -qq \
+  && apt-get install --no-install-recommends -y git \
+  && apt-get install --no-install-recommends -y make \
+  && apt-get install --no-install-recommends -y gcc \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /gem
+
+WORKDIR /gem
+
+COPY . /gem
+
+##
+# NOTE: Every container has its own copy of `Gemfile`. This way a developer doesn't need to delete `Gemfile.lock` all the time when changing containers.
+# - https://docs.docker.com/engine/reference/builder/#env
+# - https://stackoverflow.com/questions/48863711/is-it-possible-to-override-gemfile-for-local-development
+#
+ENV BUNDLE_GEMFILE=Gemfile.3.2
+
+RUN bundle install
+
+RUN bundle exec appraisal install
+
+##
+# NOTE: Installs `task`.
+# https://taskfile.dev/installation/#install-script
+#
+# NOTE: `task` is installed into `~/bin`. That is why `-b /bin` is used. See `echo ${PATH}` to debug.
+#
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /bin
+
+##
+# NOTE: Is used to check whether a command is executed inside a Docker container. See Rakefile for examples.
+# https://stackoverflow.com/a/65942222/12201472
+#
+ENV IN_DOCKER_CONTAINER=true


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Add ruby 3.2 support to CI and Docker

## How it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Updated `ci.yml`
- Updated `Taskfile.yml`
- Added `docker/3.2/Dockerfile`
- Pointed `appraisal` gem to the thoughtbot fork to fix the `Errno::ENOENT` issue

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green.
