### PR TITLE
CS-45: Replace Support::Command to ConvenientService::Command in examples

### DIFF
--- a/lib/convenient_service/examples/standard/request_params/utils/array/wrap.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/array/wrap.rb
@@ -6,7 +6,7 @@ module ConvenientService
       module RequestParams
         module Utils
           module Array
-            class Wrap < Support::Command
+            class Wrap < ConvenientService::Command
               ##
               # @!attribute [r] pad
               #   @return [Object] Can be any type.

--- a/lib/convenient_service/examples/standard/request_params/utils/http/request/parse_body.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/http/request/parse_body.rb
@@ -10,7 +10,7 @@ module ConvenientService
               ##
               # TODO: Specs.
               #
-              class ParseBody < Support::Command
+              class ParseBody < ConvenientService::Command
                 attr_reader :http_string
 
                 def initialize(http_string:)

--- a/lib/convenient_service/examples/standard/request_params/utils/http/request/parse_path.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/http/request/parse_path.rb
@@ -10,7 +10,7 @@ module ConvenientService
               ##
               # TODO: Specs.
               #
-              class ParsePath < Support::Command
+              class ParsePath < ConvenientService::Command
                 attr_reader :http_string
 
                 def initialize(http_string:)

--- a/lib/convenient_service/examples/standard/request_params/utils/integer/safe_parse.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/integer/safe_parse.rb
@@ -12,7 +12,7 @@ module ConvenientService
             ##
             # TODO: Specs.
             #
-            class SafeParse < Support::Command
+            class SafeParse < ConvenientService::Command
               attr_reader :object
 
               def initialize(object)

--- a/lib/convenient_service/examples/standard/request_params/utils/json/safe_parse.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/json/safe_parse.rb
@@ -14,7 +14,7 @@ module ConvenientService
       module RequestParams
         module Utils
           module JSON
-            class SafeParse < Support::Command
+            class SafeParse < ConvenientService::Command
               attr_reader :json_string, :default_value
 
               def initialize(json_string, default_value: nil)

--- a/lib/convenient_service/examples/standard/request_params/utils/object/blank.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/object/blank.rb
@@ -12,7 +12,7 @@ module ConvenientService
             ##
             # TODO: Specs.
             #
-            class Blank < Support::Command
+            class Blank < ConvenientService::Command
               attr_reader :object
 
               def initialize(object)

--- a/lib/convenient_service/examples/standard/request_params/utils/object/present.rb
+++ b/lib/convenient_service/examples/standard/request_params/utils/object/present.rb
@@ -12,7 +12,7 @@ module ConvenientService
             ##
             # TODO: Specs.
             #
-            class Present < Support::Command
+            class Present < ConvenientService::Command
               attr_reader :object
 
               def initialize(object)


### PR DESCRIPTION
## What was done as a part of this PR?

- Replaced `Support::Command` to `ConvenientService::Command`.

## Why it was done?

- To follow proper [layering](https://github.com/marian13/convenient_service/wiki/Design:-Communication-Graph). `Support` is a too low-level layer in regards to examples.

## How to test?

- https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests.

## Notes

- convenient_service/lib/convenient_service/aliases.rb
  ```ruby
  module ConvenientService
    Command = ::ConvenientService::Support::Command
    # ...
  end
  ```
  
## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [x] CI is green. 2629 examples, 0 failures
