### PR TITLE
CS-50: Introduce linting of magic numbers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,11 @@ require:
   # NOTE: Custom Standard cop that should be loaded before `config/base.yml`.
   #
   - standard/cop/block_single_line_braces
+  ##
+  # A RuboCop Cop that detects the use of magic numbers within instance methods.
+  # https://github.com/meetcleo/rubocop-magic_numbers
+  #
+  - rubocop-magic_numbers
 
 inherit_gem:
   standard: config/base.yml
@@ -43,3 +48,15 @@ AllCops:
     # NOTE: Excludes dependencies from linting.
     #
     - lib/convenient_service/dependencies/**/*
+
+MagicNumbers:
+  Exclude:
+    ##
+    # NOTE: Excludes the following files/folders from linting magic numbers.
+    # - https://github.com/meetcleo/rubocop-magic_numbers
+    # - https://docs.rubocop.org/rubocop/configuration.html#includingexcluding-files
+    #
+    - Rakefile
+    - benchmark/**/*
+    - spec/**/*
+    - test/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,18 @@ group :development, :test do
   gem "appraisal", github: "thoughtbot/appraisal", ref: "b200e636903700098bef25f4f51dbc4c46e4c04c"
 end
 
+group :development do
+  ##
+  # TODO: Move to `gemspec` if `rubocop-magic_numbers` maintainers agree to support Ruby 2.7. Delete otherwise.
+  #   ##
+  #   # Used for linting magic numbers in Ruby files.
+  #   # https://github.com/meetcleo/rubocop-magic_numbers
+  #   #
+  #   spec.add_development_dependency "rubocop-magic_numbers", "~> 0.4.0"
+  #
+  gem "rubocop-magic_numbers", github: "marian13/rubocop-magic_numbers", ref: "752ed423bc1969fe4dbd7ab62274ec9ea9202f01"
+end
+
 ##
 # TODO: Uncomment if a license key is approved.
 # - https://github.com/mbj/mutant/tree/a19e11a07e71a40cfa62636f7aea611e314de841#getting-an-opensource-license


### PR DESCRIPTION
## What was done as a part of this PR?
<!--- Describe your changes -->

- Set up [rubocop-magic_numbers](https://github.com/meetcleo/rubocop-magic_numbers) from a [fork](https://github.com/marian13/rubocop-magic_numbers).
- Configured [rubocop-magic_numbers](https://github.com/meetcleo/rubocop-magic_numbers) to 
lint only `lib` directory.
- **TODO:** Fixed all [rubocop-magic_numbers](https://github.com/meetcleo/rubocop-magic_numbers) complaints.

## Why it was done?
<!--- Why is this change required? Does it improve something? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- To automate magic constants lookup.  

## How to test?

- `task test`
- [Development: Local Development#tests](https://github.com/marian13/convenient_service/wiki/Development:-Local-Development#tests).

## Checklist:

- [ ] I have performed a self-review of my code.
- [ ] I have added/adjusted tests that prove my fix is effective or that my feature works.
- [ ] CI is green.
